### PR TITLE
Hide TMDB API key inputs

### DIFF
--- a/frontend/src/components/BootstrapPage.vue
+++ b/frontend/src/components/BootstrapPage.vue
@@ -72,9 +72,8 @@
           <div v-else class="ui-dialog-body">
             <div v-if="selectedStep === 'tmdb'" class="ui-dialog-section">
               <label class="ui-dialog-item-title block">{{ $t('settings.metadata.tmdbApiKey') }}</label>
-              <InputText
+              <SecretInput
                 v-model="config.themoviedb.api_key"
-                class="w-full"
                 :placeholder="$t('settings.metadata.apiKeyPlaceholder')"
                 autocomplete="off"
               />
@@ -320,6 +319,7 @@ import Button from 'primevue/button'
 import Card from 'primevue/card'
 import InputText from 'primevue/inputtext'
 import AppTag from '@/components/common/AppTag.vue'
+import SecretInput from '@/components/common/SecretInput.vue'
 import DirectoryConfig from '@/components/config/DirectoryConfig.vue'
 import DownloaderConfig from '@/components/config/DownloaderConfig.vue'
 import IndexerConfig from '@/components/config/IndexerConfig.vue'

--- a/frontend/src/components/common/SecretInput.vue
+++ b/frontend/src/components/common/SecretInput.vue
@@ -1,0 +1,67 @@
+<template>
+  <InputGroup>
+    <InputText
+      :id="inputId"
+      :model-value="modelValue"
+      :type="inputType"
+      :placeholder="placeholder"
+      :autocomplete="autocomplete"
+      class="w-full"
+      @update:model-value="$emit('update:modelValue', $event)"
+    />
+    <InputGroupAddon class="p-none">
+      <Button
+        :icon="visible ? 'pi pi-eye-slash' : 'pi pi-eye'"
+        severity="secondary"
+        text
+        class="secret-input-toggle"
+        :aria-label="visible ? $t('common.hideSecret') : $t('common.showSecret')"
+        @click="toggleVisible"
+      />
+    </InputGroupAddon>
+  </InputGroup>
+</template>
+
+<script setup>
+import { computed, ref } from 'vue'
+import Button from 'primevue/button'
+import InputGroup from 'primevue/inputgroup'
+import InputGroupAddon from 'primevue/inputgroupaddon'
+import InputText from 'primevue/inputtext'
+
+defineProps({
+  modelValue: {
+    type: String,
+    default: '',
+  },
+  inputId: {
+    type: String,
+    default: undefined,
+  },
+  placeholder: {
+    type: String,
+    default: '',
+  },
+  autocomplete: {
+    type: String,
+    default: 'off',
+  },
+})
+
+defineEmits(['update:modelValue'])
+
+const visible = ref(false)
+const inputType = computed(() => (visible.value ? 'text' : 'password'))
+
+function toggleVisible() {
+  visible.value = !visible.value
+}
+</script>
+
+<style scoped>
+.secret-input-toggle {
+  width: var(--size-control-md);
+  min-width: var(--size-control-md);
+  height: var(--size-control-md);
+}
+</style>

--- a/frontend/src/components/config/MetadataConfig.vue
+++ b/frontend/src/components/config/MetadataConfig.vue
@@ -43,11 +43,10 @@
         <div class="grid grid-cols-1 md:grid-cols-2 gap-item items-center">
           <div class="ui-dialog-section m-none md:self-center">
             <label for="tmdb-api-key" class="ui-dialog-item-title block">{{ $t('common.apiKey') }}</label>
-            <InputText
-              id="tmdb-api-key"
+            <SecretInput
               v-model="tmdb.api_key"
+              input-id="tmdb-api-key"
               :placeholder="$t('settings.metadata.apiKeyPlaceholder')"
-              class="w-full"
             />
           </div>
           <div class="ui-dialog-section m-none">
@@ -133,7 +132,6 @@
 
 <script setup>
 import { computed, reactive, ref, onMounted, watch } from 'vue'
-import InputText from 'primevue/inputtext'
 import Button from 'primevue/button'
 import PickList from 'primevue/picklist'
 import ToggleSwitch from 'primevue/toggleswitch'
@@ -143,6 +141,7 @@ import { useNotificationStore } from '@/stores/notification'
 import { useMediaImageSettingsStore } from '@/stores/media-image-settings'
 import { saveDoubanConfig, saveServicesConfig, saveTMDBConfig } from '@/api/config'
 import { getDiscoverListMetas } from '@/api/discover'
+import SecretInput from '@/components/common/SecretInput.vue'
 
 const props = defineProps({
   config: {

--- a/frontend/src/i18n/locales/en-US.js
+++ b/frontend/src/i18n/locales/en-US.js
@@ -41,6 +41,8 @@ export default {
     networkError: 'Network error: {message}',
     connectionSuccess: 'Connection succeeded',
     unknownError: 'Unknown error',
+    showSecret: 'Show secret',
+    hideSecret: 'Hide secret',
   },
   empty: {
     noData: 'No data',

--- a/frontend/src/i18n/locales/zh-CN.js
+++ b/frontend/src/i18n/locales/zh-CN.js
@@ -41,6 +41,8 @@ export default {
     networkError: '网络错误: {message}',
     connectionSuccess: '连接成功',
     unknownError: '未知错误',
+    showSecret: '显示密钥',
+    hideSecret: '隐藏密钥',
   },
   empty: {
     noData: '暂无数据',


### PR DESCRIPTION
## Summary
- Add a reusable secret input with an eye toggle for sensitive text fields.
- Use it for TMDB API Key in both the bootstrap wizard and metadata settings page.
- Add localized accessible labels for showing and hiding secrets.

## Verification
- Manually verified in the running frontend container after restarting `frontend`.
- `docker compose -f docker-compose.dev.yml run --rm --no-deps frontend npm run quality`
- `./scripts/review_with_gates.sh`