### PR TITLE
fix: handle Prowlarr Torznab search modes

### DIFF
--- a/backend/app/clients/base.py
+++ b/backend/app/clients/base.py
@@ -80,6 +80,7 @@ class IndexerClient(BaseClient):
         query: str,
         category: str | None = None,
         search_param: str = "auto",
+        season_number: int | None = None,
     ) -> list[ResourceSearchResult]:
         """Internal helper."""
         pass
@@ -96,8 +97,15 @@ class IndexerClient(BaseClient):
         query: str,
         category: str | None = None,
         search_param: str = "auto",
+        season_number: int | None = None,
     ) -> list[ResourceSearchResult]:
-        return await self.search_indexer_torznab(site_id, query, category=category, search_param=search_param)
+        return await self.search_indexer_torznab(
+            site_id,
+            query,
+            category=category,
+            search_param=search_param,
+            season_number=season_number,
+        )
 
     async def get_site_health(self) -> list[IndexerSiteHealthStatus]:
         return []

--- a/backend/app/clients/base.py
+++ b/backend/app/clients/base.py
@@ -81,6 +81,7 @@ class IndexerClient(BaseClient):
         category: str | None = None,
         search_param: str = "auto",
         season_number: int | None = None,
+        capabilities: SiteSearchCapabilities | None = None,
     ) -> list[ResourceSearchResult]:
         """Internal helper."""
         pass
@@ -98,6 +99,7 @@ class IndexerClient(BaseClient):
         category: str | None = None,
         search_param: str = "auto",
         season_number: int | None = None,
+        capabilities: SiteSearchCapabilities | None = None,
     ) -> list[ResourceSearchResult]:
         return await self.search_indexer_torznab(
             site_id,
@@ -105,6 +107,7 @@ class IndexerClient(BaseClient):
             category=category,
             search_param=search_param,
             season_number=season_number,
+            capabilities=capabilities,
         )
 
     async def get_site_health(self) -> list[IndexerSiteHealthStatus]:

--- a/backend/app/clients/jackett.py
+++ b/backend/app/clients/jackett.py
@@ -9,7 +9,6 @@ import logging
 import re
 import time
 import xml.etree.ElementTree as ET
-from datetime import datetime
 from types import TracebackType
 from urllib.parse import urlencode, urlsplit, urlunsplit
 
@@ -19,7 +18,7 @@ from app.schemas.config import IndexerProviderConfig
 from app.schemas.constants.indexer import SITE_SEARCH_TIMEOUT_SECONDS
 from app.schemas.domain.resource_search import JackettSearchResponse, JackettSearchResult, ResourceSearchResult
 from app.schemas.integration.site_models import SiteInfo, SiteSearchCapabilities
-from app.clients.torznab import format_size, parse_torznab_caps_xml, parse_torznab_xml, truncate_text
+from app.clients.torznab import build_torznab_search_params, format_size, parse_torznab_caps_xml, parse_torznab_xml, truncate_text
 
 logger = logging.getLogger("app.clients.jackett")
 
@@ -302,7 +301,8 @@ class JackettClient(IndexerClient):
         url = f"{self.base_url}/api/v2.0/indexers/all/results"
         try:
             async with self.session.get(url, params=params, timeout=self.search_timeout) as resp:
-                if resp.status != 200: return []
+                if resp.status != 200:
+                    return []
                 data_json = await resp.json()
                 data = JackettSearchResponse.model_validate(data_json)
                 return data.Results
@@ -328,7 +328,8 @@ class JackettClient(IndexerClient):
         url = f"{self.base_url}/api/v2.0/indexers/all/results/torznab"
         try:
             async with self.session.get(url, params=params, timeout=self.search_timeout) as resp:
-                if resp.status != 200: return []
+                if resp.status != 200:
+                    return []
                 text = await resp.text()
                 return self._parse_torznab_xml(text)
         except (aiohttp.ClientError, asyncio.TimeoutError, ValueError) as exc:
@@ -348,20 +349,16 @@ class JackettClient(IndexerClient):
         query: str,
         category: str | None = None,
         search_param: str = "auto",
+        season_number: int | None = None,
     ) -> list[ResourceSearchResult]:
         self._ensure_session()
-        params: dict[str, str] = {"apikey": self.api_key, "t": "search"}
-        if search_param == "doubanid":
-            params["doubanid"] = query
-        elif search_param == "imdbid" or (search_param == "auto" and re.match(r"^tt\d{7,8}$", query)):
-            params["imdbid"] = query
-        else:
-            params["q"] = query
-
-        if category:
-            category_map = {"movie": "2000", "tv": "5000", "anime": "5070"}
-            if category in category_map:
-                params["cat"] = category_map[category]
+        params = build_torznab_search_params(
+            api_key=self.api_key,
+            query=query,
+            search_param=search_param,
+            category=category,
+            search_type="search",
+        )
 
         url = f"{self.base_url}/api/v2.0/indexers/{indexer}/results/torznab"
         try:
@@ -410,7 +407,8 @@ class JackettClient(IndexerClient):
         url = f"{self.base_url}/api/v2.0/indexers/{indexer}/results"
         try:
             async with self.session.get(url, params=params, timeout=self.search_timeout) as resp:
-                if resp.status != 200: return []
+                if resp.status != 200:
+                    return []
                 data_json = await resp.json()
                 data = JackettSearchResponse.model_validate(data_json)
                 return data.Results

--- a/backend/app/clients/jackett.py
+++ b/backend/app/clients/jackett.py
@@ -350,6 +350,7 @@ class JackettClient(IndexerClient):
         category: str | None = None,
         search_param: str = "auto",
         season_number: int | None = None,
+        capabilities: SiteSearchCapabilities | None = None,
     ) -> list[ResourceSearchResult]:
         self._ensure_session()
         params = build_torznab_search_params(

--- a/backend/app/clients/prowlarr.py
+++ b/backend/app/clients/prowlarr.py
@@ -110,8 +110,9 @@ class ProwlarrClient(IndexerClient):
         supports = item.get("supportsSearch")
         return SiteSearchCapabilities(
             supports_search=bool(supports) if supports is not None else True,
-            supports_movie_search=bool(supports) if supports is not None else True,
-            supports_tv_search=bool(supports) if supports is not None else True,
+            supports_movie_search=False,
+            supports_tv_search=False,
+            search_params={"q"} if supports is not False else set(),
             supports_q=bool(supports) if supports is not None else True,
             supports_imdbid=False,
             supports_doubanid=False,
@@ -370,6 +371,28 @@ class ProwlarrClient(IndexerClient):
             return "search"
         return None
 
+    def _search_type_supports_param(
+        self,
+        search_type: str,
+        search_param: str,
+        capabilities: SiteSearchCapabilities,
+    ) -> bool:
+        param_map = {
+            "search": capabilities.search_params,
+            "movie": capabilities.movie_search_params,
+            "tvsearch": capabilities.tv_search_params,
+        }
+        declared_params = param_map.get(search_type, set())
+        if declared_params:
+            return search_param in declared_params or (search_param == "auto" and "q" in declared_params)
+        if search_param == "q":
+            return capabilities.supports_q
+        if search_param == "imdbid":
+            return capabilities.supports_imdbid
+        if search_param == "doubanid":
+            return capabilities.supports_doubanid
+        return search_param == "auto" and capabilities.supports_q
+
     def _build_torznab_search_params(
         self,
         query: str,
@@ -378,9 +401,16 @@ class ProwlarrClient(IndexerClient):
         season_number: int | None,
         capabilities: SiteSearchCapabilities | None = None,
     ) -> dict[str, str] | None:
+        has_explicit_capabilities = capabilities is not None
         resolved_capabilities = capabilities or SiteSearchCapabilities()
         search_type = self._torznab_search_type(category, search_param, resolved_capabilities)
         if search_type is None:
+            return None
+        if has_explicit_capabilities and not self._search_type_supports_param(
+            search_type,
+            search_param,
+            resolved_capabilities,
+        ):
             return None
         return build_torznab_search_params(
             api_key=self.api_key,

--- a/backend/app/clients/prowlarr.py
+++ b/backend/app/clients/prowlarr.py
@@ -393,6 +393,18 @@ class ProwlarrClient(IndexerClient):
             return capabilities.supports_doubanid
         return search_param == "auto" and capabilities.supports_q
 
+    def _torznab_season_param(
+        self,
+        search_type: str,
+        season_number: int | None,
+        capabilities: SiteSearchCapabilities,
+    ) -> int | None:
+        if search_type != "tvsearch" or season_number is None or season_number <= 0:
+            return None
+        if capabilities.tv_search_params and "season" not in capabilities.tv_search_params:
+            return None
+        return season_number
+
     def _build_torznab_search_params(
         self,
         query: str,
@@ -418,5 +430,5 @@ class ProwlarrClient(IndexerClient):
             search_param=search_param,
             category=category,
             search_type=search_type,
-            season_number=season_number if search_type == "tvsearch" else None,
+            season_number=self._torznab_season_param(search_type, season_number, resolved_capabilities),
         )

--- a/backend/app/clients/prowlarr.py
+++ b/backend/app/clients/prowlarr.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import re
 import time
 from datetime import datetime
 from types import TracebackType
@@ -16,7 +15,7 @@ from app.schemas.constants.indexer import SITE_SEARCH_TIMEOUT_SECONDS
 from app.schemas.domain.resource_search import ResourceSearchResult
 from app.schemas.integration.site_models import SiteInfo, SiteSearchCapabilities
 from app.schemas.runtime.indexer_site_health import IndexerSiteHealthStatus
-from app.clients.torznab import parse_torznab_caps_xml, parse_torznab_xml
+from app.clients.torznab import build_torznab_search_params, parse_torznab_caps_xml, parse_torznab_xml
 
 logger = logging.getLogger("app.clients.prowlarr")
 
@@ -110,6 +109,9 @@ class ProwlarrClient(IndexerClient):
             supports_tv = True
         supports = item.get("supportsSearch")
         return SiteSearchCapabilities(
+            supports_search=bool(supports) if supports is not None else True,
+            supports_movie_search=bool(supports) if supports is not None else True,
+            supports_tv_search=bool(supports) if supports is not None else True,
             supports_q=bool(supports) if supports is not None else True,
             supports_imdbid=False,
             supports_doubanid=False,
@@ -292,20 +294,20 @@ class ProwlarrClient(IndexerClient):
         query: str,
         category: str | None = None,
         search_param: str = "auto",
+        season_number: int | None = None,
     ) -> list[ResourceSearchResult]:
         self._ensure_session()
-        params: dict[str, str] = {"apikey": self.api_key, "t": "search"}
-        if search_param == "doubanid":
-            params["doubanid"] = query
-        elif search_param == "imdbid" or (search_param == "auto" and re.match(r"^tt\d{7,8}$", query)):
-            params["imdbid"] = query
-        else:
-            params["q"] = query
-
-        if category:
-            category_map = {"movie": "2000", "tv": "5000", "anime": "5070"}
-            if category in category_map:
-                params["cat"] = category_map[category]
+        capabilities = await self.get_indexer_caps(indexer)
+        params = self._build_torznab_search_params(query, category, search_param, season_number, capabilities)
+        if params is None:
+            logger.debug(
+                "Prowlarr torznab single indexer skipped unsupported search mode: indexer=%s query=%s category=%s search_param=%s",
+                indexer,
+                query,
+                category,
+                search_param,
+            )
+            return []
 
         url = f"{self.base_url}/{indexer}/api"
         try:
@@ -345,3 +347,46 @@ class ProwlarrClient(IndexerClient):
                 exc,
             )
             raise RuntimeError(message) from exc
+
+    def _torznab_search_type(
+        self,
+        category: str | None,
+        search_param: str,
+        capabilities: SiteSearchCapabilities,
+    ) -> str | None:
+        if category == "tv":
+            if capabilities.supports_tv_search:
+                return "tvsearch"
+            if search_param == "q" and capabilities.supports_search:
+                return "search"
+            return None
+        if category == "movie":
+            if capabilities.supports_movie_search:
+                return "movie"
+            if search_param == "q" and capabilities.supports_search:
+                return "search"
+            return None
+        if capabilities.supports_search:
+            return "search"
+        return None
+
+    def _build_torznab_search_params(
+        self,
+        query: str,
+        category: str | None,
+        search_param: str,
+        season_number: int | None,
+        capabilities: SiteSearchCapabilities | None = None,
+    ) -> dict[str, str] | None:
+        resolved_capabilities = capabilities or SiteSearchCapabilities()
+        search_type = self._torznab_search_type(category, search_param, resolved_capabilities)
+        if search_type is None:
+            return None
+        return build_torznab_search_params(
+            api_key=self.api_key,
+            query=query,
+            search_param=search_param,
+            category=category,
+            search_type=search_type,
+            season_number=season_number if search_type == "tvsearch" else None,
+        )

--- a/backend/app/clients/prowlarr.py
+++ b/backend/app/clients/prowlarr.py
@@ -15,7 +15,12 @@ from app.schemas.constants.indexer import SITE_SEARCH_TIMEOUT_SECONDS
 from app.schemas.domain.resource_search import ResourceSearchResult
 from app.schemas.integration.site_models import SiteInfo, SiteSearchCapabilities
 from app.schemas.runtime.indexer_site_health import IndexerSiteHealthStatus
-from app.clients.torznab import build_torznab_search_params, parse_torznab_caps_xml, parse_torznab_xml
+from app.clients.torznab import (
+    build_torznab_search_params,
+    parse_torznab_caps_xml,
+    parse_torznab_xml,
+    resolve_torznab_search_param,
+)
 
 logger = logging.getLogger("app.clients.prowlarr")
 
@@ -296,10 +301,11 @@ class ProwlarrClient(IndexerClient):
         category: str | None = None,
         search_param: str = "auto",
         season_number: int | None = None,
+        capabilities: SiteSearchCapabilities | None = None,
     ) -> list[ResourceSearchResult]:
         self._ensure_session()
-        capabilities = await self.get_indexer_caps(indexer)
-        params = self._build_torznab_search_params(query, category, search_param, season_number, capabilities)
+        resolved_capabilities = capabilities or await self.get_indexer_caps(indexer)
+        params = self._build_torznab_search_params(query, category, search_param, season_number, resolved_capabilities)
         if params is None:
             logger.debug(
                 "Prowlarr torznab single indexer skipped unsupported search mode: indexer=%s query=%s category=%s search_param=%s",
@@ -356,18 +362,34 @@ class ProwlarrClient(IndexerClient):
         capabilities: SiteSearchCapabilities,
     ) -> str | None:
         if category == "tv":
-            if capabilities.supports_tv_search:
+            if capabilities.supports_tv_search and self._search_type_supports_param(
+                "tvsearch",
+                search_param,
+                capabilities,
+            ):
                 return "tvsearch"
-            if search_param == "q" and capabilities.supports_search:
+            if (
+                search_param == "q"
+                and capabilities.supports_search
+                and self._search_type_supports_param("search", search_param, capabilities)
+            ):
                 return "search"
             return None
         if category == "movie":
-            if capabilities.supports_movie_search:
+            if capabilities.supports_movie_search and self._search_type_supports_param(
+                "movie",
+                search_param,
+                capabilities,
+            ):
                 return "movie"
-            if search_param == "q" and capabilities.supports_search:
+            if (
+                search_param == "q"
+                and capabilities.supports_search
+                and self._search_type_supports_param("search", search_param, capabilities)
+            ):
                 return "search"
             return None
-        if capabilities.supports_search:
+        if capabilities.supports_search and self._search_type_supports_param("search", search_param, capabilities):
             return "search"
         return None
 
@@ -384,14 +406,14 @@ class ProwlarrClient(IndexerClient):
         }
         declared_params = param_map.get(search_type, set())
         if declared_params:
-            return search_param in declared_params or (search_param == "auto" and "q" in declared_params)
+            return search_param in declared_params
         if search_param == "q":
             return capabilities.supports_q
         if search_param == "imdbid":
             return capabilities.supports_imdbid
         if search_param == "doubanid":
             return capabilities.supports_doubanid
-        return search_param == "auto" and capabilities.supports_q
+        return False
 
     def _torznab_season_param(
         self,
@@ -413,21 +435,15 @@ class ProwlarrClient(IndexerClient):
         season_number: int | None,
         capabilities: SiteSearchCapabilities | None = None,
     ) -> dict[str, str] | None:
-        has_explicit_capabilities = capabilities is not None
         resolved_capabilities = capabilities or SiteSearchCapabilities()
-        search_type = self._torznab_search_type(category, search_param, resolved_capabilities)
+        resolved_search_param = resolve_torznab_search_param(query, search_param)
+        search_type = self._torznab_search_type(category, resolved_search_param, resolved_capabilities)
         if search_type is None:
-            return None
-        if has_explicit_capabilities and not self._search_type_supports_param(
-            search_type,
-            search_param,
-            resolved_capabilities,
-        ):
             return None
         return build_torznab_search_params(
             api_key=self.api_key,
             query=query,
-            search_param=search_param,
+            search_param=resolved_search_param,
             category=category,
             search_type=search_type,
             season_number=self._torznab_season_param(search_type, season_number, resolved_capabilities),

--- a/backend/app/clients/torznab.py
+++ b/backend/app/clients/torznab.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import re
 import uuid
 import xml.etree.ElementTree as ET
 from datetime import datetime, timezone
@@ -30,6 +31,31 @@ def truncate_text(value: str | None, limit: int = 300) -> str:
     if len(text) <= limit:
         return text
     return f"{text[:limit].rstrip()}..."
+
+
+def build_torznab_search_params(
+    *,
+    api_key: str,
+    query: str,
+    search_param: str,
+    category: str | None = None,
+    search_type: str = "search",
+    season_number: int | None = None,
+) -> dict[str, str]:
+    params: dict[str, str] = {"apikey": api_key, "t": search_type}
+    if search_param == "doubanid":
+        params["doubanid"] = query
+    elif search_param == "imdbid" or (search_param == "auto" and re.match(r"^tt\d{7,8}$", query)):
+        params["imdbid"] = query
+    else:
+        params["q"] = query
+
+    category_map = {"movie": "2000", "tv": "5000", "anime": "5070"}
+    if category in category_map:
+        params["cat"] = category_map[category]
+    if season_number is not None and season_number > 0:
+        params["season"] = str(season_number)
+    return params
 
 
 def parse_torznab_xml(xml_text: str, *, default_site: str = "unknown") -> list[ResourceSearchResult]:
@@ -137,12 +163,17 @@ def parse_torznab_caps_xml(xml_text: str) -> SiteSearchCapabilities:
         return SiteSearchCapabilities()
 
     params: set[str] = set()
+    available_search_types: set[str] = set()
+    declared_search_types: set[str] = set()
     searching = root.find(".//searching")
     if searching is not None:
         for child in list(searching):
+            search_type = child.tag.rsplit("}", 1)[-1].lower()
+            declared_search_types.add(search_type)
             available = str(child.attrib.get("available", "")).strip().lower()
             if available in {"no", "false", "0"}:
                 continue
+            available_search_types.add(search_type)
             supported = child.attrib.get("supportedParams", "") or ""
             for param in supported.split(","):
                 normalized = param.strip().lower()
@@ -161,6 +192,9 @@ def parse_torznab_caps_xml(xml_text: str) -> SiteSearchCapabilities:
         supports_tv = True
 
     return SiteSearchCapabilities(
+        supports_search="search" in available_search_types if declared_search_types else True,
+        supports_movie_search="movie-search" in available_search_types if declared_search_types else True,
+        supports_tv_search="tv-search" in available_search_types if declared_search_types else True,
         supports_doubanid="doubanid" in params,
         supports_imdbid="imdbid" in params,
         supports_q="q" in params if params else True,

--- a/backend/app/clients/torznab.py
+++ b/backend/app/clients/torznab.py
@@ -162,7 +162,7 @@ def parse_torznab_caps_xml(xml_text: str) -> SiteSearchCapabilities:
         logger.warning("Failed to parse Torznab caps XML: %s", exc)
         return SiteSearchCapabilities()
 
-    params: set[str] = set()
+    params_by_search_type: dict[str, set[str]] = {}
     available_search_types: set[str] = set()
     declared_search_types: set[str] = set()
     searching = root.find(".//searching")
@@ -174,11 +174,14 @@ def parse_torznab_caps_xml(xml_text: str) -> SiteSearchCapabilities:
             if available in {"no", "false", "0"}:
                 continue
             available_search_types.add(search_type)
+            search_type_params: set[str] = set()
             supported = child.attrib.get("supportedParams", "") or ""
             for param in supported.split(","):
                 normalized = param.strip().lower()
                 if normalized:
-                    params.add(normalized)
+                    search_type_params.add(normalized)
+            params_by_search_type[search_type] = search_type_params
+    params = set().union(*params_by_search_type.values()) if params_by_search_type else set()
 
     category_ids: set[str] = set()
     for category in root.findall(".//categories//category"):
@@ -195,6 +198,9 @@ def parse_torznab_caps_xml(xml_text: str) -> SiteSearchCapabilities:
         supports_search="search" in available_search_types if declared_search_types else True,
         supports_movie_search="movie-search" in available_search_types if declared_search_types else True,
         supports_tv_search="tv-search" in available_search_types if declared_search_types else True,
+        search_params=params_by_search_type.get("search", set()),
+        movie_search_params=params_by_search_type.get("movie-search", set()),
+        tv_search_params=params_by_search_type.get("tv-search", set()),
         supports_doubanid="doubanid" in params,
         supports_imdbid="imdbid" in params,
         supports_q="q" in params if params else True,

--- a/backend/app/clients/torznab.py
+++ b/backend/app/clients/torznab.py
@@ -43,9 +43,10 @@ def build_torznab_search_params(
     season_number: int | None = None,
 ) -> dict[str, str]:
     params: dict[str, str] = {"apikey": api_key, "t": search_type}
-    if search_param == "doubanid":
+    resolved_search_param = resolve_torznab_search_param(query, search_param)
+    if resolved_search_param == "doubanid":
         params["doubanid"] = query
-    elif search_param == "imdbid" or (search_param == "auto" and re.match(r"^tt\d{7,8}$", query)):
+    elif resolved_search_param == "imdbid":
         params["imdbid"] = query
     else:
         params["q"] = query
@@ -56,6 +57,14 @@ def build_torznab_search_params(
     if season_number is not None and season_number > 0:
         params["season"] = str(season_number)
     return params
+
+
+def resolve_torznab_search_param(query: str, search_param: str) -> str:
+    if search_param != "auto":
+        return search_param
+    if re.match(r"^tt\d{7,8}$", query):
+        return "imdbid"
+    return "q"
 
 
 def parse_torznab_xml(xml_text: str, *, default_site: str = "unknown") -> list[ResourceSearchResult]:

--- a/backend/app/schemas/integration/site_models.py
+++ b/backend/app/schemas/integration/site_models.py
@@ -13,6 +13,9 @@ class SiteInfo(BaseModel):
 
 
 class SiteSearchCapabilities(BaseModel):
+    supports_search: bool = True
+    supports_movie_search: bool = True
+    supports_tv_search: bool = True
     supports_doubanid: bool = False
     supports_imdbid: bool = False
     supports_q: bool = True

--- a/backend/app/schemas/integration/site_models.py
+++ b/backend/app/schemas/integration/site_models.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from app.schemas.domain.media_types import MediaType
 
@@ -16,6 +16,9 @@ class SiteSearchCapabilities(BaseModel):
     supports_search: bool = True
     supports_movie_search: bool = True
     supports_tv_search: bool = True
+    search_params: set[str] = Field(default_factory=set)
+    movie_search_params: set[str] = Field(default_factory=set)
+    tv_search_params: set[str] = Field(default_factory=set)
     supports_doubanid: bool = False
     supports_imdbid: bool = False
     supports_q: bool = True

--- a/backend/app/services/application/workflows/resource_search/service.py
+++ b/backend/app/services/application/workflows/resource_search/service.py
@@ -5,6 +5,7 @@ import time
 from dataclasses import dataclass
 
 from app.schemas.domain.resource_search import MediaSearchQuery, ResourceSearchResult
+from app.schemas.domain.media_types import MediaType
 from app.schemas.media_id import MediaID
 from app.schemas.runtime.indexer_runtime import IndexerSiteSearchOutcome
 from app.schemas.runtime.indexer_runtime import IndexerSearchContext
@@ -21,6 +22,8 @@ class _SiteSearchPlan:
     context: IndexerSearchContext
     modes: list[tuple[str, str]]
     query_scope: str
+    media_type: MediaType | None
+    season_number: int | None
 
 
 class ResourceSearchService:
@@ -115,7 +118,15 @@ class ResourceSearchService:
                     continue
                 scheduled_site_count += 1
                 mode_request_count += len(modes)
-                scheduled_plans.append(_SiteSearchPlan(context=context, modes=modes, query_scope=query_scope))
+                scheduled_plans.append(
+                    _SiteSearchPlan(
+                        context=context,
+                        modes=modes,
+                        query_scope=query_scope,
+                        media_type=query.media_type,
+                        season_number=query.season_number,
+                    )
+                )
                 ordered_entries.append(("scheduled", None))
 
         scheduled_results = await self._search_site_plans(scheduled_plans)
@@ -212,7 +223,12 @@ class ResourceSearchService:
 
     async def _search_site_plan(self, plan: _SiteSearchPlan) -> tuple[_SiteSearchPlan, IndexerSiteSearchResult]:
         try:
-            result = await self._search_site_modes(plan.context, plan.modes)
+            result = await self._search_site_modes(
+                plan.context,
+                plan.modes,
+                media_type=plan.media_type,
+                season_number=plan.season_number,
+            )
         except Exception:
             logger.exception(
                 "Resource media search site task failed: client=%s site=%s",
@@ -370,6 +386,8 @@ class ResourceSearchService:
         self,
         context: IndexerSearchContext,
         modes: list[tuple[str, str]],
+        media_type: MediaType | None = None,
+        season_number: int | None = None,
     ) -> IndexerSiteSearchResult:
         site_results: list[ResourceSearchResult] = []
         outcomes: list[IndexerSiteSearchOutcome] = []
@@ -383,7 +401,13 @@ class ResourceSearchService:
                 search_param,
                 query_text,
             )
-            result = await self.indexer_gateway.search_context(context, query_text, search_param)
+            result = await self.indexer_gateway.search_context(
+                context,
+                query_text,
+                search_param,
+                media_type=media_type,
+                season_number=season_number,
+            )
             outcomes.extend(result.outcomes)
             site_results.extend(result.results)
             site_failed = site_failed or result.failed

--- a/backend/app/services/integration/indexer/gateway.py
+++ b/backend/app/services/integration/indexer/gateway.py
@@ -63,20 +63,40 @@ class IndexerGateway:
         sites: list[SiteInfo],
         query: str,
         search_param: str,
+        media_type: MediaType | None = None,
+        season_number: int | None = None,
     ) -> IndexerSiteSearchResult:
-        return await self._site_searcher.search_sites_by_query(client, sites, query, search_param)
+        category = media_type.value if media_type else None
+        return await self._site_searcher.search_sites_by_query(
+            client,
+            sites,
+            query,
+            search_param,
+            category=category,
+            season_number=season_number,
+        )
 
     async def search_context(
         self,
         context: IndexerSearchContext,
         query: str,
         search_param: str,
+        media_type: MediaType | None = None,
+        season_number: int | None = None,
     ) -> IndexerSiteSearchResult:
         client = self._client_by_id(context.indexer_id)
         if client is None:
             logger.warning("Indexer search skipped because client is unavailable: indexer=%s", context.indexer_id)
             return IndexerSiteSearchResult(results=[], failed=True, searched=False, outcomes=[])
-        return await self._site_searcher.search_sites_by_query(client, [context.site], query, search_param)
+        category = media_type.value if media_type else None
+        return await self._site_searcher.search_sites_by_query(
+            client,
+            [context.site],
+            query,
+            search_param,
+            category=category,
+            season_number=season_number,
+        )
 
     async def list_search_contexts(
         self,

--- a/backend/app/services/integration/indexer/gateway.py
+++ b/backend/app/services/integration/indexer/gateway.py
@@ -96,6 +96,7 @@ class IndexerGateway:
             search_param,
             category=category,
             season_number=season_number,
+            capabilities_by_site={context.site.id: context.capabilities},
         )
 
     async def list_search_contexts(

--- a/backend/app/services/integration/indexer/site_search.py
+++ b/backend/app/services/integration/indexer/site_search.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 
 from app.clients.base import IndexerClient
 from app.schemas.domain.resource_search import ResourceSearchResult
-from app.schemas.integration.site_models import SiteInfo
+from app.schemas.integration.site_models import SiteInfo, SiteSearchCapabilities
 from app.schemas.runtime.indexer_runtime import IndexerSiteSearchOutcome
 from app.services.integration.indexer.site_scope import scoped_site_id
 
@@ -32,12 +32,22 @@ class IndexerSiteSearcher:
         search_param: str,
         category: str | None = None,
         season_number: int | None = None,
+        capabilities_by_site: dict[str, SiteSearchCapabilities] | None = None,
     ) -> IndexerSiteSearchResult:
         if not sites:
             return IndexerSiteSearchResult(results=[], failed=False, searched=False, outcomes=[])
         semaphore = asyncio.Semaphore(self._concurrency)
         outcomes = await asyncio.gather(*(
-            self.search_site_by_query(client, site, query, search_param, semaphore, category, season_number)
+            self.search_site_by_query(
+                client,
+                site,
+                query,
+                search_param,
+                semaphore,
+                category,
+                season_number,
+                capabilities_by_site.get(site.id) if capabilities_by_site else None,
+            )
             for site in sites
         ))
 
@@ -68,11 +78,19 @@ class IndexerSiteSearcher:
         semaphore: asyncio.Semaphore,
         category: str | None = None,
         season_number: int | None = None,
+        capabilities: SiteSearchCapabilities | None = None,
     ) -> IndexerSiteSearchOutcome:
         async with semaphore:
             try:
                 results = await asyncio.wait_for(
-                    client.search_site(site.id, query, category=category, search_param=search_param, season_number=season_number),
+                    client.search_site(
+                        site.id,
+                        query,
+                        category=category,
+                        search_param=search_param,
+                        season_number=season_number,
+                        capabilities=capabilities,
+                    ),
                     timeout=self._timeout,
                 )
                 initial_matched_by_id = search_param in {"doubanid", "imdbid"}

--- a/backend/app/services/integration/indexer/site_search.py
+++ b/backend/app/services/integration/indexer/site_search.py
@@ -30,12 +30,14 @@ class IndexerSiteSearcher:
         sites: list[SiteInfo],
         query: str,
         search_param: str,
+        category: str | None = None,
+        season_number: int | None = None,
     ) -> IndexerSiteSearchResult:
         if not sites:
             return IndexerSiteSearchResult(results=[], failed=False, searched=False, outcomes=[])
         semaphore = asyncio.Semaphore(self._concurrency)
         outcomes = await asyncio.gather(*(
-            self.search_site_by_query(client, site, query, search_param, semaphore)
+            self.search_site_by_query(client, site, query, search_param, semaphore, category, season_number)
             for site in sites
         ))
 
@@ -64,11 +66,13 @@ class IndexerSiteSearcher:
         query: str,
         search_param: str,
         semaphore: asyncio.Semaphore,
+        category: str | None = None,
+        season_number: int | None = None,
     ) -> IndexerSiteSearchOutcome:
         async with semaphore:
             try:
                 results = await asyncio.wait_for(
-                    client.search_site(site.id, query, search_param=search_param),
+                    client.search_site(site.id, query, category=category, search_param=search_param, season_number=season_number),
                     timeout=self._timeout,
                 )
                 initial_matched_by_id = search_param in {"doubanid", "imdbid"}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,5 @@
-fastapi
+fastapi==0.136.1
+starlette==1.0.0
 uvicorn[standard]
 httpx
 aiohttp

--- a/backend/tests/test_indexer_result_id_consistency.py
+++ b/backend/tests/test_indexer_result_id_consistency.py
@@ -42,6 +42,7 @@ class FakeIndexerClient(IndexerClient):
         query: str,
         category: str | None = None,
         search_param: str = "auto",
+        season_number: int | None = None,
     ) -> list[ResourceSearchResult]:
         self.calls.append((indexer, search_param, query))
         return [

--- a/backend/tests/test_indexer_result_id_consistency.py
+++ b/backend/tests/test_indexer_result_id_consistency.py
@@ -43,6 +43,7 @@ class FakeIndexerClient(IndexerClient):
         category: str | None = None,
         search_param: str = "auto",
         season_number: int | None = None,
+        capabilities: SiteSearchCapabilities | None = None,
     ) -> list[ResourceSearchResult]:
         self.calls.append((indexer, search_param, query))
         return [

--- a/backend/tests/test_indexer_site_search_modes.py
+++ b/backend/tests/test_indexer_site_search_modes.py
@@ -84,6 +84,7 @@ class RecordingIndexerClient(IndexerClient):
         category: str | None = None,
         search_param: str = "auto",
         season_number: int | None = None,
+        capabilities: SiteSearchCapabilities | None = None,
     ) -> list[ResourceSearchResult]:
         self.calls.append((indexer, search_param))
         return [
@@ -188,6 +189,7 @@ class ExternalDoubanIdClient(RecordingIndexerClient):
         category: str | None = None,
         search_param: str = "auto",
         season_number: int | None = None,
+        capabilities: SiteSearchCapabilities | None = None,
     ) -> list[ResourceSearchResult]:
         self.calls.append((indexer, search_param))
         self.queries.append((indexer, search_param, query))
@@ -315,6 +317,7 @@ class ConcurrentModeClient(IndexerClient):
         category: str | None = None,
         search_param: str = "auto",
         season_number: int | None = None,
+        capabilities: SiteSearchCapabilities | None = None,
     ) -> list[ResourceSearchResult]:
         self.calls.append((indexer, search_param))
         self.in_flight += 1
@@ -324,6 +327,34 @@ class ConcurrentModeClient(IndexerClient):
             return []
         finally:
             self.in_flight -= 1
+
+
+class CapabilityRecordingClient(RecordingIndexerClient):
+    def __init__(self) -> None:
+        super().__init__()
+        self.config.site_settings = []
+        self.capability_calls = 0
+        self.seen_capabilities: list[SiteSearchCapabilities | None] = []
+
+    async def get_indexers(self) -> list[SiteInfo]:
+        return [SiteInfo(id="site-a", name="Site A", description="A", language="", type="private")]
+
+    async def get_indexer_caps(self, indexer: str) -> SiteSearchCapabilities:
+        self.capability_calls += 1
+        return SiteSearchCapabilities(supports_q=True, supports_imdbid=True, supports_doubanid=True)
+
+    async def search_indexer_torznab(
+        self,
+        indexer: str,
+        query: str,
+        category: str | None = None,
+        search_param: str = "auto",
+        season_number: int | None = None,
+        capabilities: SiteSearchCapabilities | None = None,
+    ) -> list[ResourceSearchResult]:
+        self.calls.append((indexer, search_param))
+        self.seen_capabilities.append(capabilities)
+        return []
 
 
 @pytest.mark.asyncio
@@ -348,6 +379,26 @@ async def test_search_media_runs_sites_concurrently_and_modes_sequentially_per_s
             "imdbid",
             "q",
         ]
+
+
+@pytest.mark.asyncio
+async def test_search_media_reuses_resolved_site_capabilities_for_each_mode():
+    runtime_cache.clear()
+    client = CapabilityRecordingClient()
+    service = ResourceSearchService(indexer_gateway=IndexerGateway(client=client))
+    query = _query(
+        "tmdb:tv:789",
+        title="Example Show",
+        imdb_id="tt7654321",
+        douban_id="36513446",
+        season_number=1,
+    )
+
+    await service.search_media(query)
+
+    assert client.capability_calls == 1
+    assert client.calls == [("site-a", "doubanid"), ("site-a", "imdbid"), ("site-a", "q")]
+    assert all(capability is not None for capability in client.seen_capabilities)
 
 
 class SingleSiteClient(RecordingIndexerClient):

--- a/backend/tests/test_indexer_site_search_modes.py
+++ b/backend/tests/test_indexer_site_search_modes.py
@@ -83,6 +83,7 @@ class RecordingIndexerClient(IndexerClient):
         query: str,
         category: str | None = None,
         search_param: str = "auto",
+        season_number: int | None = None,
     ) -> list[ResourceSearchResult]:
         self.calls.append((indexer, search_param))
         return [
@@ -186,6 +187,7 @@ class ExternalDoubanIdClient(RecordingIndexerClient):
         query: str,
         category: str | None = None,
         search_param: str = "auto",
+        season_number: int | None = None,
     ) -> list[ResourceSearchResult]:
         self.calls.append((indexer, search_param))
         self.queries.append((indexer, search_param, query))
@@ -312,6 +314,7 @@ class ConcurrentModeClient(IndexerClient):
         query: str,
         category: str | None = None,
         search_param: str = "auto",
+        season_number: int | None = None,
     ) -> list[ResourceSearchResult]:
         self.calls.append((indexer, search_param))
         self.in_flight += 1

--- a/backend/tests/test_prowlarr_client.py
+++ b/backend/tests/test_prowlarr_client.py
@@ -2,7 +2,8 @@ from datetime import datetime
 
 from app.clients.prowlarr import ProwlarrClient
 from app.schemas.config import ProwlarrConfig
-from app.clients.torznab import parse_torznab_xml
+from app.clients.torznab import build_torznab_search_params, parse_torznab_xml
+from app.schemas.integration.site_models import SiteSearchCapabilities
 
 
 def test_prowlarr_client_maps_enabled_torrent_indexer_to_site():
@@ -50,8 +51,165 @@ def test_prowlarr_capabilities_are_derived_from_categories():
     assert caps.supports_q is True
     assert caps.supports_imdbid is False
     assert caps.supports_doubanid is False
+    assert caps.supports_search is True
     assert caps.supports_movie is True
     assert caps.supports_tv is True
+
+
+def test_prowlarr_torznab_tv_id_search_uses_tvsearch_mode_and_season():
+    client = ProwlarrClient(
+        ProwlarrConfig(id="prowlarr-1", name="Prowlarr", url="http://prowlarr:9696", api_key="key")
+    )
+
+    params = client._build_torznab_search_params("tt36982480", "tv", "imdbid", 1)
+
+    assert params == {
+        "apikey": "key",
+        "t": "tvsearch",
+        "imdbid": "tt36982480",
+        "cat": "5000",
+        "season": "1",
+    }
+
+
+def test_prowlarr_torznab_tv_title_search_uses_tvsearch_mode_and_season():
+    client = ProwlarrClient(
+        ProwlarrConfig(id="prowlarr-1", name="Prowlarr", url="http://prowlarr:9696", api_key="key")
+    )
+
+    params = client._build_torznab_search_params("耀眼", "tv", "q", 1)
+
+    assert params == {
+        "apikey": "key",
+        "t": "tvsearch",
+        "q": "耀眼",
+        "cat": "5000",
+        "season": "1",
+    }
+
+
+def test_shared_torznab_search_params_map_search_modes():
+    params = build_torznab_search_params(
+        api_key="key",
+        query="36513446",
+        search_param="doubanid",
+        category="tv",
+        search_type="search",
+    )
+
+    assert params == {
+        "apikey": "key",
+        "t": "search",
+        "doubanid": "36513446",
+        "cat": "5000",
+    }
+
+
+def test_prowlarr_torznab_movie_title_search_falls_back_to_generic_search_when_movie_mode_unavailable():
+    client = ProwlarrClient(
+        ProwlarrConfig(id="prowlarr-1", name="Prowlarr", url="http://prowlarr:9696", api_key="key")
+    )
+
+    params = client._build_torznab_search_params(
+        "The Shawshank Redemption",
+        "movie",
+        "q",
+        None,
+        SiteSearchCapabilities(supports_search=True, supports_movie_search=False),
+    )
+
+    assert params == {
+        "apikey": "key",
+        "t": "search",
+        "q": "The Shawshank Redemption",
+        "cat": "2000",
+    }
+
+
+def test_prowlarr_torznab_movie_id_search_does_not_fall_back_to_generic_search():
+    client = ProwlarrClient(
+        ProwlarrConfig(id="prowlarr-1", name="Prowlarr", url="http://prowlarr:9696", api_key="key")
+    )
+
+    params = client._build_torznab_search_params(
+        "tt0111161",
+        "movie",
+        "imdbid",
+        None,
+        SiteSearchCapabilities(supports_search=True, supports_movie_search=False),
+    )
+
+    assert params is None
+
+
+def test_prowlarr_torznab_movie_id_search_skips_generic_id_search_even_when_caps_advertise_id_param():
+    client = ProwlarrClient(
+        ProwlarrConfig(id="prowlarr-1", name="Prowlarr", url="http://prowlarr:9696", api_key="key")
+    )
+
+    params = client._build_torznab_search_params(
+        "tt0111161",
+        "movie",
+        "imdbid",
+        None,
+        SiteSearchCapabilities(
+            supports_search=True,
+            supports_movie_search=False,
+            supports_imdbid=True,
+        ),
+    )
+
+    assert params is None
+
+
+def test_prowlarr_torznab_tv_title_fallback_omits_season_without_tvsearch():
+    client = ProwlarrClient(
+        ProwlarrConfig(id="prowlarr-1", name="Prowlarr", url="http://prowlarr:9696", api_key="key")
+    )
+
+    params = client._build_torznab_search_params(
+        "Game of Thrones S01",
+        "tv",
+        "q",
+        1,
+        SiteSearchCapabilities(supports_search=True, supports_tv_search=False),
+    )
+
+    assert params == {
+        "apikey": "key",
+        "t": "search",
+        "q": "Game of Thrones S01",
+        "cat": "5000",
+    }
+
+
+def test_prowlarr_torznab_movie_id_search_uses_movie_mode():
+    client = ProwlarrClient(
+        ProwlarrConfig(id="prowlarr-1", name="Prowlarr", url="http://prowlarr:9696", api_key="key")
+    )
+
+    params = client._build_torznab_search_params("tt1234567", "movie", "imdbid", None)
+
+    assert params == {
+        "apikey": "key",
+        "t": "movie",
+        "imdbid": "tt1234567",
+        "cat": "2000",
+    }
+
+
+def test_prowlarr_plain_search_only_uses_search_mode_without_media_category():
+    client = ProwlarrClient(
+        ProwlarrConfig(id="prowlarr-1", name="Prowlarr", url="http://prowlarr:9696", api_key="key")
+    )
+
+    params = client._build_torznab_search_params("耀眼", None, "q", None)
+
+    assert params == {
+        "apikey": "key",
+        "t": "search",
+        "q": "耀眼",
+    }
 
 
 def test_shared_torznab_caps_parser_maps_search_params():
@@ -74,8 +232,32 @@ def test_shared_torznab_caps_parser_maps_search_params():
     assert caps.supports_q is True
     assert caps.supports_imdbid is True
     assert caps.supports_doubanid is True
+    assert caps.supports_search is True
+    assert caps.supports_movie_search is False
+    assert caps.supports_tv_search is False
     assert caps.supports_movie is True
     assert caps.supports_tv is True
+
+
+def test_shared_torznab_caps_parser_maps_available_search_types():
+    from app.clients.torznab import parse_torznab_caps_xml
+
+    caps = parse_torznab_caps_xml(
+        """
+        <caps>
+          <searching>
+            <search available="yes" supportedParams="q" />
+            <tv-search available="yes" supportedParams="q,season,ep,imdbid" />
+            <movie-search available="no" supportedParams="q,imdbid" />
+          </searching>
+        </caps>
+        """
+    )
+
+    assert caps.supports_search is True
+    assert caps.supports_tv_search is True
+    assert caps.supports_movie_search is False
+    assert caps.supports_imdbid is True
 
 
 def test_shared_torznab_parser_maps_prowlarr_feed_result():

--- a/backend/tests/test_prowlarr_client.py
+++ b/backend/tests/test_prowlarr_client.py
@@ -52,6 +52,8 @@ def test_prowlarr_capabilities_are_derived_from_categories():
     assert caps.supports_imdbid is False
     assert caps.supports_doubanid is False
     assert caps.supports_search is True
+    assert caps.supports_movie_search is False
+    assert caps.supports_tv_search is False
     assert caps.supports_movie is True
     assert caps.supports_tv is True
 
@@ -162,6 +164,28 @@ def test_prowlarr_torznab_movie_id_search_skips_generic_id_search_even_when_caps
     assert params is None
 
 
+def test_prowlarr_torznab_tv_id_search_skips_param_not_supported_by_tvsearch():
+    client = ProwlarrClient(
+        ProwlarrConfig(id="prowlarr-1", name="Prowlarr", url="http://prowlarr:9696", api_key="key")
+    )
+
+    params = client._build_torznab_search_params(
+        "36513446",
+        "tv",
+        "doubanid",
+        1,
+        SiteSearchCapabilities(
+            supports_search=True,
+            supports_tv_search=True,
+            search_params={"q", "doubanid"},
+            tv_search_params={"q", "season", "imdbid"},
+            supports_doubanid=True,
+        ),
+    )
+
+    assert params is None
+
+
 def test_prowlarr_torznab_tv_title_fallback_omits_season_without_tvsearch():
     client = ProwlarrClient(
         ProwlarrConfig(id="prowlarr-1", name="Prowlarr", url="http://prowlarr:9696", api_key="key")
@@ -258,6 +282,9 @@ def test_shared_torznab_caps_parser_maps_available_search_types():
     assert caps.supports_tv_search is True
     assert caps.supports_movie_search is False
     assert caps.supports_imdbid is True
+    assert caps.search_params == {"q"}
+    assert caps.tv_search_params == {"q", "season", "ep", "imdbid"}
+    assert caps.movie_search_params == set()
 
 
 def test_shared_torznab_parser_maps_prowlarr_feed_result():

--- a/backend/tests/test_prowlarr_client.py
+++ b/backend/tests/test_prowlarr_client.py
@@ -90,6 +90,57 @@ def test_prowlarr_torznab_tv_title_search_uses_tvsearch_mode_and_season():
     }
 
 
+def test_prowlarr_torznab_tv_search_keeps_season_when_tvsearch_declares_season():
+    client = ProwlarrClient(
+        ProwlarrConfig(id="prowlarr-1", name="Prowlarr", url="http://prowlarr:9696", api_key="key")
+    )
+
+    params = client._build_torznab_search_params(
+        "耀眼",
+        "tv",
+        "q",
+        1,
+        SiteSearchCapabilities(
+            supports_tv_search=True,
+            tv_search_params={"q", "season"},
+            supports_q=True,
+        ),
+    )
+
+    assert params == {
+        "apikey": "key",
+        "t": "tvsearch",
+        "q": "耀眼",
+        "cat": "5000",
+        "season": "1",
+    }
+
+
+def test_prowlarr_torznab_tv_search_omits_season_when_tvsearch_does_not_declare_season():
+    client = ProwlarrClient(
+        ProwlarrConfig(id="prowlarr-1", name="Prowlarr", url="http://prowlarr:9696", api_key="key")
+    )
+
+    params = client._build_torznab_search_params(
+        "耀眼",
+        "tv",
+        "q",
+        1,
+        SiteSearchCapabilities(
+            supports_tv_search=True,
+            tv_search_params={"q", "imdbid"},
+            supports_q=True,
+        ),
+    )
+
+    assert params == {
+        "apikey": "key",
+        "t": "tvsearch",
+        "q": "耀眼",
+        "cat": "5000",
+    }
+
+
 def test_shared_torznab_search_params_map_search_modes():
     params = build_torznab_search_params(
         api_key="key",

--- a/backend/tests/test_prowlarr_client.py
+++ b/backend/tests/test_prowlarr_client.py
@@ -63,7 +63,16 @@ def test_prowlarr_torznab_tv_id_search_uses_tvsearch_mode_and_season():
         ProwlarrConfig(id="prowlarr-1", name="Prowlarr", url="http://prowlarr:9696", api_key="key")
     )
 
-    params = client._build_torznab_search_params("tt36982480", "tv", "imdbid", 1)
+    params = client._build_torznab_search_params(
+        "tt36982480",
+        "tv",
+        "imdbid",
+        1,
+        SiteSearchCapabilities(
+            supports_tv_search=True,
+            supports_imdbid=True,
+        ),
+    )
 
     assert params == {
         "apikey": "key",
@@ -237,6 +246,81 @@ def test_prowlarr_torznab_tv_id_search_skips_param_not_supported_by_tvsearch():
     assert params is None
 
 
+def test_prowlarr_torznab_auto_search_checks_resolved_imdb_param_support():
+    client = ProwlarrClient(
+        ProwlarrConfig(id="prowlarr-1", name="Prowlarr", url="http://prowlarr:9696", api_key="key")
+    )
+
+    params = client._build_torznab_search_params(
+        "tt1234567",
+        "tv",
+        "auto",
+        1,
+        SiteSearchCapabilities(
+            supports_tv_search=True,
+            tv_search_params={"q", "season"},
+            supports_imdbid=True,
+            supports_q=True,
+        ),
+    )
+
+    assert params is None
+
+
+def test_prowlarr_torznab_tv_title_search_falls_back_when_tvsearch_does_not_support_q():
+    client = ProwlarrClient(
+        ProwlarrConfig(id="prowlarr-1", name="Prowlarr", url="http://prowlarr:9696", api_key="key")
+    )
+
+    params = client._build_torznab_search_params(
+        "Game of Thrones S01",
+        "tv",
+        "q",
+        1,
+        SiteSearchCapabilities(
+            supports_search=True,
+            supports_tv_search=True,
+            search_params={"q"},
+            tv_search_params={"imdbid", "season"},
+            supports_q=True,
+        ),
+    )
+
+    assert params == {
+        "apikey": "key",
+        "t": "search",
+        "q": "Game of Thrones S01",
+        "cat": "5000",
+    }
+
+
+def test_prowlarr_torznab_movie_title_search_falls_back_when_movie_search_does_not_support_q():
+    client = ProwlarrClient(
+        ProwlarrConfig(id="prowlarr-1", name="Prowlarr", url="http://prowlarr:9696", api_key="key")
+    )
+
+    params = client._build_torznab_search_params(
+        "The Shawshank Redemption",
+        "movie",
+        "q",
+        None,
+        SiteSearchCapabilities(
+            supports_search=True,
+            supports_movie_search=True,
+            search_params={"q"},
+            movie_search_params={"imdbid"},
+            supports_q=True,
+        ),
+    )
+
+    assert params == {
+        "apikey": "key",
+        "t": "search",
+        "q": "The Shawshank Redemption",
+        "cat": "2000",
+    }
+
+
 def test_prowlarr_torznab_tv_title_fallback_omits_season_without_tvsearch():
     client = ProwlarrClient(
         ProwlarrConfig(id="prowlarr-1", name="Prowlarr", url="http://prowlarr:9696", api_key="key")
@@ -263,7 +347,16 @@ def test_prowlarr_torznab_movie_id_search_uses_movie_mode():
         ProwlarrConfig(id="prowlarr-1", name="Prowlarr", url="http://prowlarr:9696", api_key="key")
     )
 
-    params = client._build_torznab_search_params("tt1234567", "movie", "imdbid", None)
+    params = client._build_torznab_search_params(
+        "tt1234567",
+        "movie",
+        "imdbid",
+        None,
+        SiteSearchCapabilities(
+            supports_movie_search=True,
+            supports_imdbid=True,
+        ),
+    )
 
     assert params == {
         "apikey": "key",

--- a/frontend/src/composables/useResourceSearchLifecycle.js
+++ b/frontend/src/composables/useResourceSearchLifecycle.js
@@ -45,7 +45,10 @@ export function useResourceSearchLifecycle({
   watch(
     () => props.initialResults,
     (results) => {
-      if (!Array.isArray(results)) return
+      if (!Array.isArray(results)) {
+        clearSearchResults({ keepHasSearched: props.hasSearched || props.alwaysShowResults })
+        return
+      }
       setSearchResults(results)
     },
   )


### PR DESCRIPTION
## Problem

Prowlarr Torznab media searches did not distinguish generic `search`, `tv-search`, and `movie-search` capabilities. That created two issues:

- TV/movie resource searches did not reliably pass media type and season context down to site-level Torznab requests.
- Using generic `t=search` with ID parameters such as `imdbid` or `doubanid` can degrade into broad result sets on some Prowlarr sites, often returning 50/100 capped results instead of precise ID matches.

## Cause

The resource search chain only propagated the query text and search parameter. Media type and season number were not carried into site-level searches. `SiteSearchCapabilities` also tracked category and parameter support, but not whether the Torznab caps exposed generic `search`, `tv-search`, or `movie-search` as available search functions.

## Fix

- Propagate media type and season number through resource search plans, the indexer gateway, and site search clients.
- Add shared Torznab search parameter construction for Jackett and Prowlarr.
- Track `supports_search`, `supports_tv_search`, and `supports_movie_search` from Prowlarr caps.
- Use `t=tvsearch` / `t=movie` when the site advertises dedicated support.
- Allow fallback to `t=search&cat=...` only for title (`q`) searches.
- Explicitly avoid falling back media ID searches to generic `t=search&imdbid/doubanid=...` to prevent broad-result pollution.
- Clear frontend resource search state when initial results are absent.
- Pin backend FastAPI/Starlette versions so CI and local Docker gates use the same TestClient behavior.

## Verification

- `./aethera.sh test-backend tests/test_prowlarr_client.py`
- `./aethera.sh test-backend tests/test_prowlarr_client.py tests/test_indexer_site_search_modes.py`
- `./scripts/review_with_gates.sh`

## Notes

Local Prowlarr testing showed that `t=search&imdbid=...&cat=...` often returns broad capped results, while `t=movie` / `t=tvsearch` returns narrowed media results. The fallback is therefore intentionally limited to title searches.