### PR TITLE
Fix pilot download config resolution

### DIFF
--- a/backend/app/api/v1/resource/pilot_episode.py
+++ b/backend/app/api/v1/resource/pilot_episode.py
@@ -3,8 +3,6 @@ from pydantic import BaseModel
 
 from app.api.v1.commands.responses import CommandResponse
 from app.schemas.domain.media import MediaTarget
-from app.schemas.domain.subscription import SubscriptionUnmatchedRule
-from app.schemas.domain.subscription_filters import SubscriptionFilters
 from app.services.application.workflows.subscription.pilot import pilot_download_application_service
 
 router = APIRouter()
@@ -12,21 +10,11 @@ router = APIRouter()
 
 class PilotEpisodeRequest(BaseModel):
     target: MediaTarget
-    directory_id: str
-    sites: list[str] | None = None
-    filters: SubscriptionFilters | None = None
-    quality_profile_id: str | None = None
-    unmatched_rules: list[SubscriptionUnmatchedRule] | None = None
 
 
 @router.post("/pilot_episode", response_model=CommandResponse)
 async def queue_pilot_episode(body: PilotEpisodeRequest) -> CommandResponse:
     command = await pilot_download_application_service.queue(
         target=body.target,
-        directory_id=body.directory_id,
-        filters=body.filters,
-        quality_profile_id=body.quality_profile_id,
-        sites=body.sites,
-        unmatched_rules=body.unmatched_rules,
     )
     return CommandResponse(command=command)

--- a/backend/app/schemas/domain/command.py
+++ b/backend/app/schemas/domain/command.py
@@ -8,8 +8,6 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from app.schemas.domain.download import DownloadTaskCreateInput
 from app.schemas.domain.media import MediaExecutionSnapshot, MediaTarget
-from app.schemas.domain.subscription import SubscriptionUnmatchedRule
-from app.schemas.domain.subscription_filters import SubscriptionFilters
 from app.schemas.media_id import MediaID
 
 
@@ -75,11 +73,6 @@ class TaskCreateCommandRequestPayload(DownloadTaskCreateInput):
 
 class PilotEpisodeCommandRequestPayload(PayloadBase):
     target: MediaTarget
-    directory_id: str
-    site_ids: list[str] = Field(default_factory=list)
-    filters: SubscriptionFilters | None = None
-    quality_profile_id: str | None = None
-    unmatched_rules: list[SubscriptionUnmatchedRule] = Field(default_factory=list)
 
 
 class TaskTransferCommandRequestPayload(PayloadBase):
@@ -202,11 +195,6 @@ class TaskCreateCommandRecordPayload(DownloadTaskCreateInput):
 
 class PilotEpisodeCommandRecordPayload(PayloadBase):
     media: MediaExecutionSnapshot
-    directory_id: str
-    site_ids: list[str] = Field(default_factory=list)
-    filters: SubscriptionFilters | None = None
-    quality_profile_id: str | None = None
-    unmatched_rules: list[SubscriptionUnmatchedRule] = Field(default_factory=list)
 
 
 class TaskTransferCommandRecordPayload(PayloadBase):

--- a/backend/app/services/application/commands/handlers/download.py
+++ b/backend/app/services/application/commands/handlers/download.py
@@ -182,11 +182,6 @@ class PilotEpisodeCommandHandler:
         season_number = media.season_number
         payload = PilotEpisodeCommandRecordPayload(
             media=media,
-            directory_id=request.directory_id,
-            site_ids=request.site_ids,
-            filters=request.filters,
-            quality_profile_id=request.quality_profile_id or "",
-            unmatched_rules=request.unmatched_rules,
         )
         return CommandRecord(
             id=str(uuid.uuid4()),
@@ -205,11 +200,6 @@ class PilotEpisodeCommandHandler:
         payload = command.payload
         task_count = await pilot_download_application_service.execute(
             media=payload.media,
-            directory_id=payload.directory_id,
-            filters=payload.filters,
-            quality_profile_id=payload.quality_profile_id or None,
-            sites=payload.site_ids,
-            unmatched_rules=payload.unmatched_rules,
             season_number=payload.media.season_number,
         )
         return CommandResult(result_count=task_count)

--- a/backend/app/services/application/workflows/subscription/pilot.py
+++ b/backend/app/services/application/workflows/subscription/pilot.py
@@ -12,7 +12,6 @@ from app.schemas.domain.media import MediaExecutionSnapshot, MediaTarget
 from app.schemas.domain.media_types import MediaType
 from app.schemas.domain.resource_search import MediaSearchQuery
 from app.schemas.domain.subscription import SubscriptionUnmatchedRule
-from app.schemas.domain.subscription_filters import SubscriptionFilters
 from app.schemas.exception import DownloadException
 from app.schemas.exception.base import AppException
 from app.services.domain.resource.pilot_selection import select_pilot_resources
@@ -27,6 +26,7 @@ from app.services.config.settings_service import settings_service
 from app.services.domain.download import download_service
 from app.services.domain.library.service import library_service
 from app.services.domain.media import media_service
+from app.services.domain.subscription.download_config_service import subscription_download_config_service
 from app.services.application.workflows.resource_search import resource_search_service
 from app.services.platform.domain_lock_service import domain_lock_service
 
@@ -42,11 +42,6 @@ class PilotDownloadApplicationService:
         self,
         *,
         target: MediaTarget,
-        directory_id: str,
-        filters: SubscriptionFilters | None = None,
-        quality_profile_id: str | None = None,
-        sites: list[str] | None = None,
-        unmatched_rules: list[SubscriptionUnmatchedRule] | None = None,
     ):
         command = await command_service.create_command(
             CommandCreateRequest(
@@ -54,22 +49,25 @@ class PilotDownloadApplicationService:
                 initiator=CommandInitiator.MANUAL,
                 payload=PilotEpisodeCommandRequestPayload(
                     target=target,
-                    directory_id=directory_id,
-                    site_ids=list(sites or []),
-                    filters=filters,
-                    quality_profile_id=quality_profile_id,
-                    unmatched_rules=list(unmatched_rules or []),
                 ),
             )
         )
         media = command.payload.media
         if media is None:
             raise DownloadException("backendErrors.mediaExecutionSnapshotRequired")
+        effective_config = await subscription_download_config_service.resolve_effective_config(
+            media.media_id,
+            media.media_type,
+            season_number=media.season_number if media.media_type == MediaType.tv else None,
+        )
         event_service.emit_media(
             MediaEventCreate(
                 type=EventTypes.PILOT_EPISODE_QUEUED,
                 level=EventLevel.info,
-                message_params={"directory_id": directory_id, "site_count": str(len(sites or []))},
+                message_params={
+                    "directory_id": effective_config.directory_id or "",
+                    "site_count": str(len(effective_config.sites or [])),
+                },
                 media=media,
                 actor=EventActor.user,
                 source=EventSource.base,
@@ -84,11 +82,6 @@ class PilotDownloadApplicationService:
         self,
         *,
         media: MediaExecutionSnapshot,
-        directory_id: str,
-        filters: SubscriptionFilters | None = None,
-        quality_profile_id: str | None = None,
-        sites: list[str] | None = None,
-        unmatched_rules: list[SubscriptionUnmatchedRule] | None = None,
         season_number: int | None = None,
     ) -> int:
         async with self._acquire_media_execution_flow(media.media_id, reason="pilot") as acquired:
@@ -97,10 +90,24 @@ class PilotDownloadApplicationService:
             if not acquired:
                 raise DownloadException("backendErrors.mediaResourceFlowBusy")
 
-            quality_profile = (
-                settings_service.get_quality_profile(quality_profile_id)
-                if quality_profile_id else settings_service.get_default_quality_profile()
+            effective_config = await subscription_download_config_service.resolve_effective_config(
+                active_media.media_id,
+                active_media.media_type,
+                season_number=active_media.season_number if active_media.media_type == MediaType.tv else None,
             )
+            directory_id = effective_config.directory_id
+            if not directory_id:
+                raise DownloadException("backendErrors.downloadDirectoryMissing")
+            resolved_filters = effective_config.filters
+            resolved_quality_profile_id = effective_config.quality_profile_id
+            quality_profile = (
+                settings_service.get_quality_profile(resolved_quality_profile_id)
+                if resolved_quality_profile_id else (effective_config.quality_profile or settings_service.get_default_quality_profile())
+            )
+            if quality_profile is None:
+                quality_profile = effective_config.quality_profile or settings_service.get_default_quality_profile()
+            resolved_sites = effective_config.sites
+            resolved_unmatched_rules = list(effective_config.unmatched_rules)
             episode_mode = active_media.media_type == MediaType.tv
             if episode_mode:
                 if not active_media.episodes_count or active_media.season_number is None:
@@ -113,9 +120,9 @@ class PilotDownloadApplicationService:
                     active_media.media_id,
                     active_media.season_number,
                     sorted(target_episodes),
-                    sites or [],
-                    "configured" if filters else "none",
-                    len(unmatched_rules or []),
+                    resolved_sites or [],
+                    "configured" if resolved_filters else "none",
+                    len(resolved_unmatched_rules),
                 )
                 target_episodes = await self._available_pilot_target_episodes(
                     media_id=active_media.media_id,
@@ -127,9 +134,9 @@ class PilotDownloadApplicationService:
                 logger.info(
                     "Configured download started: media=%s sites=%s filters=%s unmatched_rules=%d",
                     active_media.media_id,
-                    sites or [],
-                    "configured" if filters else "none",
-                    len(unmatched_rules or []),
+                    resolved_sites or [],
+                    "configured" if resolved_filters else "none",
+                    len(resolved_unmatched_rules),
                 )
                 await self._ensure_movie_quick_download_available(active_media.media_id)
 
@@ -137,15 +144,15 @@ class PilotDownloadApplicationService:
                 media_id=active_media.media_id,
                 season_number=active_media.season_number if episode_mode else None,
                 episode_mode=episode_mode,
-                filters=filters,
+                filters=resolved_filters,
                 quality_profile=quality_profile,
                 target_episodes=target_episodes,
                 required_scores={},
             )
             selected = await self._search_and_select_resources(
                 media=active_media,
-                sites=sites,
-                unmatched_rules=unmatched_rules,
+                sites=resolved_sites,
+                unmatched_rules=resolved_unmatched_rules,
                 selection_plan=selection_plan,
                 episode_mode=episode_mode,
                 action_label=action_label,

--- a/backend/app/services/application/workflows/subscription/pilot.py
+++ b/backend/app/services/application/workflows/subscription/pilot.py
@@ -43,6 +43,19 @@ class PilotDownloadApplicationService:
         *,
         target: MediaTarget,
     ):
+        media = await media_service.resolve_execution_snapshot(
+            target.media_id,
+            season_number=target.season_number,
+            require_tv_season=True,
+            require_episode_count=True,
+        )
+        effective_config = await subscription_download_config_service.resolve_effective_config(
+            media.media_id,
+            media.media_type,
+            season_number=media.season_number if media.media_type == MediaType.tv else None,
+        )
+        if not effective_config.directory_id:
+            raise DownloadException("backendErrors.downloadDirectoryMissing")
         command = await command_service.create_command(
             CommandCreateRequest(
                 type=CommandType.PILOT_EPISODE,
@@ -55,11 +68,6 @@ class PilotDownloadApplicationService:
         media = command.payload.media
         if media is None:
             raise DownloadException("backendErrors.mediaExecutionSnapshotRequired")
-        effective_config = await subscription_download_config_service.resolve_effective_config(
-            media.media_id,
-            media.media_type,
-            season_number=media.season_number if media.media_type == MediaType.tv else None,
-        )
         event_service.emit_media(
             MediaEventCreate(
                 type=EventTypes.PILOT_EPISODE_QUEUED,

--- a/backend/tests/test_subscription_execution_pilot.py
+++ b/backend/tests/test_subscription_execution_pilot.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from app.schemas.exception.exceptions import DownloadException
-from app.schemas.domain.media import MediaExecutionSnapshot, MediaFullInfo, MediaSeasonInfo
+from app.schemas.domain.media import MediaExecutionSnapshot, MediaFullInfo, MediaSeasonInfo, MediaTarget
 from app.schemas.domain.media_types import MediaType
 from app.schemas.domain.quality_profile import QualityProfile
 from app.schemas.domain.resource_attributes import ResourceAttributes
@@ -88,6 +88,51 @@ async def test_pilot_is_rejected_only_when_full_prefix_is_occupied(monkeypatch):
             target_episodes={1, 2, 3},
         )
     assert exc_info.value.message_key == "backendErrors.pilotEpisodesAlreadyCovered"
+
+
+@pytest.mark.asyncio
+async def test_queue_pilot_episode_rejects_missing_effective_directory_before_creating_command(monkeypatch):
+    media = MediaExecutionSnapshot(
+        media_id=MediaID.parse("tmdb:tv:287641"),
+        title="Dazzling",
+        year=2026,
+        media_type=MediaType.tv,
+        season_number=1,
+        episodes_count=30,
+    )
+
+    async def fake_resolve_effective_config(_media_id, _media_type, *, season_number=None):
+        _ = season_number
+        return SimpleNamespace(
+            directory_id=None,
+            filters=None,
+            quality_profile_id=None,
+            quality_profile=None,
+            sites=None,
+            unmatched_rules=[],
+        )
+
+    create_command = AsyncMock()
+    monkeypatch.setattr(
+        "app.services.application.workflows.subscription.pilot.media_service.resolve_execution_snapshot",
+        AsyncMock(return_value=media),
+    )
+    monkeypatch.setattr(
+        "app.services.application.workflows.subscription.pilot.subscription_download_config_service.resolve_effective_config",
+        fake_resolve_effective_config,
+    )
+    monkeypatch.setattr(
+        "app.services.application.workflows.subscription.pilot.command_service.create_command",
+        create_command,
+    )
+
+    with pytest.raises(DownloadException) as exc_info:
+        await pilot_download_application_service.queue(
+            target=MediaTarget(media_id=media.media_id, season_number=1),
+        )
+
+    assert exc_info.value.message_key == "backendErrors.downloadDirectoryMissing"
+    create_command.assert_not_awaited()
 
 
 def _build_resource(

--- a/backend/tests/test_subscription_execution_pilot.py
+++ b/backend/tests/test_subscription_execution_pilot.py
@@ -10,7 +10,7 @@ from app.schemas.domain.media_types import MediaType
 from app.schemas.domain.quality_profile import QualityProfile
 from app.schemas.domain.resource_attributes import ResourceAttributes
 from app.schemas.domain.resource_search import Resource, ResourceSearchResult
-from app.schemas.domain.subscription import Subscription
+from app.schemas.domain.subscription import Subscription, SubscriptionUnmatchedRule
 from app.schemas.domain.subscription_filters import SubscriptionFilters, UpgradePolicy
 from app.schemas.domain.torrent import TorrentFileItem, TorrentMetadata, TorrentPayload
 from app.schemas.media_id import MediaID
@@ -19,6 +19,25 @@ from app.services.domain.resource.selection import ResourceSelectionPlan, partit
 from app.services.application.workflows.subscription.pilot import pilot_download_application_service
 from app.services.domain.subscription.resource_run_plan_service import resource_run_plan_service
 from app.services.application.workflows.subscription.run import SubscriptionRunApplicationService
+
+
+@pytest.fixture(autouse=True)
+def _default_effective_pilot_config(monkeypatch):
+    async def fake_resolve_effective_config(_media_id, _media_type, *, season_number=None):
+        _ = season_number
+        return SimpleNamespace(
+            directory_id="dir-default",
+            filters=None,
+            quality_profile_id=None,
+            quality_profile=None,
+            sites=None,
+            unmatched_rules=[],
+        )
+
+    monkeypatch.setattr(
+        "app.services.application.workflows.subscription.pilot.subscription_download_config_service.resolve_effective_config",
+        fake_resolve_effective_config,
+    )
 
 
 @pytest.mark.asyncio
@@ -725,11 +744,6 @@ async def test_execute_pilot_episode_fills_missing_tv_episode_count(monkeypatch)
 
     created = await pilot_download_application_service.execute(
         media=media,
-        directory_id="tv-default",
-        filters=None,
-        quality_profile_id=None,
-        sites=None,
-        unmatched_rules=None,
         season_number=1,
     )
 
@@ -798,16 +812,109 @@ async def test_execute_pilot_episode_targets_only_missing_prefix_episodes(monkey
 
     created = await pilot_download_application_service.execute(
         media=media,
-        directory_id="tv-default",
-        filters=None,
-        quality_profile_id=None,
-        sites=None,
-        unmatched_rules=None,
         season_number=1,
     )
 
     assert created == 1
     assert select_pilot.await_args.kwargs["target_episodes"] == {1}
+
+
+@pytest.mark.asyncio
+async def test_execute_pilot_episode_uses_effective_download_config(monkeypatch):
+    media = MediaExecutionSnapshot(
+        media_id=MediaID.parse("tmdb:tv:287641"),
+        title="Dazzling",
+        year=2026,
+        media_type=MediaType.tv,
+        season_number=1,
+        episodes_count=30,
+    )
+    resource = _build_resource("Dazzling S01E01-E03 2160p WEB-DL", [1, 2, 3])
+    payload = SimpleNamespace(metadata=SimpleNamespace(files=[], get_episodes=lambda: {1, 2, 3}, size=1))
+    effective_filters = SubscriptionFilters(resolution=["2160p"], exclude_keywords=["去头尾"])
+    effective_quality = QualityProfile(id="qp-effective", name="Effective")
+    effective_rule = SubscriptionUnmatchedRule(sites=["site-effective"], pattern="Dazzling S01")
+
+    class _Lock:
+        async def __aenter__(self):
+            return True
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    async def fake_resolve_effective_config(media_id, media_type, *, season_number=None):
+        assert media_id == media.media_id
+        assert media_type == MediaType.tv
+        assert season_number == 1
+        return SimpleNamespace(
+            directory_id="tv-default",
+            filters=effective_filters,
+            quality_profile_id=effective_quality.id,
+            quality_profile=effective_quality,
+            sites=["site-effective"],
+            unmatched_rules=[effective_rule],
+        )
+
+    monkeypatch.setattr(
+        "app.services.application.workflows.subscription.pilot.subscription_download_config_service.resolve_effective_config",
+        fake_resolve_effective_config,
+    )
+    monkeypatch.setattr(
+        "app.services.application.workflows.subscription.pilot.domain_lock_service.acquire_media_acquire",
+        lambda _media_id: _Lock(),
+    )
+    monkeypatch.setattr(
+        "app.services.application.workflows.subscription.pilot.settings_service.get_quality_profile",
+        lambda profile_id: effective_quality if profile_id == effective_quality.id else None,
+    )
+    monkeypatch.setattr(
+        "app.services.application.workflows.subscription.pilot.library_service.get_present_episodes",
+        AsyncMock(return_value=set()),
+    )
+    monkeypatch.setattr(
+        "app.services.application.workflows.subscription.pilot.download_service.list_active_episodes_by_media",
+        AsyncMock(return_value=set()),
+    )
+    search_media = AsyncMock(return_value=[resource.resources])
+    monkeypatch.setattr(
+        "app.services.application.workflows.subscription.pilot.resource_search_service.search_media",
+        search_media,
+    )
+
+    captured = {}
+
+    def fake_partition(plan, search_results, unmatched_rules=None):
+        captured["plan"] = plan
+        captured["unmatched_rules"] = unmatched_rules
+        return [resource], [], True
+
+    monkeypatch.setattr(
+        "app.services.application.workflows.subscription.pilot.partition_search_results",
+        fake_partition,
+    )
+    monkeypatch.setattr(
+        "app.services.application.workflows.subscription.pilot.select_pilot_resources",
+        AsyncMock(return_value=[(payload, [], resource)]),
+    )
+    monkeypatch.setattr(
+        "app.services.application.workflows.subscription.pilot.download_service.create_download",
+        AsyncMock(return_value=SimpleNamespace(id="task-1")),
+    )
+    monkeypatch.setattr(
+        "app.services.application.workflows.subscription.pilot.media_service.upsert_active_profile_from_identity",
+        AsyncMock(),
+    )
+
+    created = await pilot_download_application_service.execute(
+        media=media,
+        season_number=1,
+    )
+
+    assert created == 1
+    assert search_media.await_args.args[0].indexers == ["site-effective"]
+    assert captured["plan"].filters is effective_filters
+    assert captured["plan"].quality_profile is effective_quality
+    assert captured["unmatched_rules"] == [effective_rule]
 
 
 @pytest.mark.asyncio
@@ -886,11 +993,6 @@ async def test_execute_pilot_episode_supports_movie_quick_download(monkeypatch):
 
     created = await pilot_download_application_service.execute(
         media=media,
-        directory_id="movie-default",
-        filters=None,
-        quality_profile_id=None,
-        sites=None,
-        unmatched_rules=None,
     )
 
     assert created == 1
@@ -931,11 +1033,6 @@ async def test_execute_pilot_episode_rejects_movie_when_already_in_library(monke
     with pytest.raises(DownloadException) as exc_info:
         await pilot_download_application_service.execute(
             media=media,
-            directory_id="movie-default",
-            filters=None,
-            quality_profile_id=None,
-            sites=None,
-            unmatched_rules=None,
         )
     assert exc_info.value.message_key == "backendErrors.movieAlreadyInLibrary"
 
@@ -978,11 +1075,6 @@ async def test_execute_pilot_episode_rejects_movie_when_already_downloading(monk
     with pytest.raises(DownloadException) as exc_info:
         await pilot_download_application_service.execute(
             media=media,
-            directory_id="movie-default",
-            filters=None,
-            quality_profile_id=None,
-            sites=None,
-            unmatched_rules=None,
         )
     assert exc_info.value.message_key == "backendErrors.movieAlreadyDownloading"
 

--- a/frontend/src/composables/useMediaDetailSubscription.js
+++ b/frontend/src/composables/useMediaDetailSubscription.js
@@ -44,14 +44,6 @@ export function useMediaDetailSubscription(options = {}) {
   }))
 
   const effectiveFilters = computed(() => resolveEffectiveFilters(downloadConfig.value, defaultFilterPreset.value))
-  const effectiveQualityProfileId = computed(() => (
-    detailOverview?.value?.summary?.download_config?.quality_profile?.id
-    || downloadConfig.value?.quality_profile_id
-    || defaultFilterPreset.value?.quality_profile_id
-    || catalogs.value?.quality_profiles?.find?.((item) => item.active_default)?.id
-    || null
-  ))
-
   const filterPresetName = computed(() => resolveFilterPresetName(downloadConfig.value, defaultFilterPreset.value))
   const currentMediaType = computed(() => detail.value?.media_type || detail.value?.type)
   const activeSeasonNumber = computed(() => {
@@ -175,26 +167,12 @@ export function useMediaDetailSubscription(options = {}) {
     if (!requireSeasonContext(currentMediaType.value === 'movie' ? t('mediaDetail.downloadAction') : t('mediaDetail.pilotAction'))) return null
     const canContinue = await ensureSubscriptionReady(currentMediaType.value)
     if (!canContinue) return null
-    const directoryId = downloadConfig.value?.directory_id || defaultDirectoryId.value
-    if (!directoryId) {
-      notification.error(currentMediaType.value === 'movie' ? t('mediaDetail.noDefaultDirectoryForDownload') : t('mediaDetail.noDefaultDirectoryForPilot'))
-      return null
-    }
     try {
       const response = await downloadPilotEpisode({
         target: buildMediaTarget({
           media_id: mediaId.value,
           seasonNumber: currentMediaType.value === 'tv' ? activeSeasonNumber.value : null,
         }),
-        directory_id: directoryId,
-        sites: Array.isArray(downloadConfig.value?.sites) && downloadConfig.value.sites.length > 0
-          ? downloadConfig.value.sites
-          : undefined,
-        filters: effectiveFilters.value || undefined,
-        quality_profile_id: effectiveQualityProfileId.value || undefined,
-        unmatched_rules: Array.isArray(downloadConfig.value?.unmatched_rules) && downloadConfig.value.unmatched_rules.length > 0
-          ? downloadConfig.value.unmatched_rules
-          : undefined,
       })
       return response?.command || response || null
     } catch {

--- a/frontend/src/i18n/locales/en-US.js
+++ b/frontend/src/i18n/locales/en-US.js
@@ -291,6 +291,7 @@ export default {
     quickDownloadNoResource: 'No downloadable matching resource found',
     pilotNoMatchedResource: 'No matching pilot resource found',
     quickDownloadNoMatchedResource: 'No matching download resource found',
+    downloadDirectoryMissing: 'No download directory is configured',
     pilotEpisodesAlreadyCovered: 'Episodes 1-3 are already in library or downloading',
     movieAlreadyInLibrary: 'Movie is already in library',
     movieAlreadyDownloading: 'Movie is already downloading',

--- a/frontend/src/i18n/locales/zh-CN.js
+++ b/frontend/src/i18n/locales/zh-CN.js
@@ -291,6 +291,7 @@ export default {
     quickDownloadNoResource: '未找到可下载的匹配资源',
     pilotNoMatchedResource: '未找到符合条件的试播资源',
     quickDownloadNoMatchedResource: '未找到符合条件的下载资源',
+    downloadDirectoryMissing: '未配置下载目录，无法创建下载任务',
     pilotEpisodesAlreadyCovered: '前 1-3 集已入库或正在下载，无需试播',
     movieAlreadyInLibrary: '电影已入库，无需下载',
     movieAlreadyDownloading: '电影已在下载中，无需重复下载',


### PR DESCRIPTION
## Summary
- Make pilot download requests carry only the media target, matching subscription refresh behavior.
- Resolve directory, filters, quality profile, sites, and unmatched rules from the backend effective download config at execution time.
- Add coverage for pilot downloads using saved filter presets when the command payload does not carry filter data.

## Tests
- ./scripts/test_backend.sh tests/test_subscription_execution_pilot.py -q
- ./scripts/check_quality.sh

## Notes
- This prevents saved filter presets, such as exclude keywords, from being bypassed by a stale or incomplete frontend payload.