### PR TITLE
Add metadata source connection tests

### DIFF
--- a/backend/tests/test_config_test_connection.py
+++ b/backend/tests/test_config_test_connection.py
@@ -67,3 +67,57 @@ async def test_test_connection_accepts_rtorrent_downloader(monkeypatch):
     assert response.ok is True
     assert response.client_type == "rtorrent"
     assert seen_types == ["rtorrent"]
+
+
+@pytest.mark.asyncio
+async def test_test_connection_accepts_tmdb_config(monkeypatch):
+    seen_api_keys = []
+
+    async def fake_test_connection_for_config(config):
+        seen_api_keys.append(config.api_key)
+        return True
+
+    monkeypatch.setattr(
+        test_connection.tmdb_integration,
+        "test_connection_for_config",
+        fake_test_connection_for_config,
+    )
+
+    response = await test_connection.test_service_connection(
+        ServiceConnectionRequestPayload(
+            type="themoviedb",
+            config=ConnectionConfigPayload(
+                api_key="tmdb-key",
+            ),
+        )
+    )
+
+    assert response.ok is True
+    assert response.client_type == "themoviedb"
+    assert seen_api_keys == ["tmdb-key"]
+
+
+@pytest.mark.asyncio
+async def test_test_connection_accepts_douban_config(monkeypatch):
+    seen_discover_lists = []
+
+    async def fake_test_connection_for_config(config):
+        seen_discover_lists.append(config.discover_lists)
+        return True
+
+    monkeypatch.setattr(
+        test_connection.douban_integration,
+        "test_connection_for_config",
+        fake_test_connection_for_config,
+    )
+
+    response = await test_connection.test_service_connection(
+        ServiceConnectionRequestPayload(
+            type="douban",
+            config=ConnectionConfigPayload(),
+        )
+    )
+
+    assert response.ok is True
+    assert response.client_type == "douban"
+    assert seen_discover_lists == [["movie_hot_gaia", "tv_hot", "tv_animation", "tv_variety_show"]]

--- a/frontend/src/components/config/MetadataConfig.vue
+++ b/frontend/src/components/config/MetadataConfig.vue
@@ -37,7 +37,17 @@
             {{ $t('settings.metadata.tmdbApplyApiKey') }}
           </p>
         </div>
-        <Button :label="$t('common.save')" icon="pi pi-save" :loading="savingTMDB" @click="saveTMDB" />
+        <div class="flex flex-wrap justify-end gap-item">
+          <Button
+            :label="$t('settings.metadata.testConnection')"
+            icon="pi pi-wifi"
+            severity="secondary"
+            outlined
+            :loading="testingTMDB"
+            @click="testTMDBConnection"
+          />
+          <Button :label="$t('common.save')" icon="pi pi-save" :loading="savingTMDB" @click="saveTMDB" />
+        </div>
       </div>
       <div class="ui-settings-card-body">
         <div class="grid grid-cols-1 md:grid-cols-2 gap-item items-center">
@@ -90,7 +100,17 @@
           <h4 class="m-none text-subtitle font-semibold text-color">{{ $t('settings.metadata.doubanTitle') }}</h4>
           <p class="m-none text-caption text-muted">{{ $t('settings.metadata.doubanDescription') }}</p>
         </div>
-        <Button :label="$t('common.save')" icon="pi pi-save" :loading="savingDouban" @click="saveDouban" />
+        <div class="flex flex-wrap justify-end gap-item">
+          <Button
+            :label="$t('settings.metadata.testConnection')"
+            icon="pi pi-wifi"
+            severity="secondary"
+            outlined
+            :loading="testingDouban"
+            @click="testDoubanConnection"
+          />
+          <Button :label="$t('common.save')" icon="pi pi-save" :loading="savingDouban" @click="saveDouban" />
+        </div>
       </div>
       <div class="ui-settings-card-body">
         <div class="ui-dialog-section">
@@ -139,7 +159,7 @@ import Select from 'primevue/select'
 import { useI18n } from 'vue-i18n'
 import { useNotificationStore } from '@/stores/notification'
 import { useMediaImageSettingsStore } from '@/stores/media-image-settings'
-import { saveDoubanConfig, saveServicesConfig, saveTMDBConfig } from '@/api/config'
+import { saveDoubanConfig, saveServicesConfig, saveTMDBConfig, testServiceConnection } from '@/api/config'
 import { getDiscoverListMetas } from '@/api/discover'
 import SecretInput from '@/components/common/SecretInput.vue'
 
@@ -160,6 +180,8 @@ const { t } = useI18n()
 const savingTMDB = ref(false)
 const savingDouban = ref(false)
 const savingSource = ref(false)
+const testingTMDB = ref(false)
+const testingDouban = ref(false)
 const loadingDoubanOptions = ref(false)
 const loadingTMDBOptions = ref(false)
 const browseSource = ref('douban')
@@ -305,6 +327,29 @@ const saveTMDB = async () => {
   }
 }
 
+const testTMDBConnection = async () => {
+  const apiKey = tmdb.api_key.trim()
+  if (!apiKey) {
+    notification.warn(t('settings.metadata.tmdbApiKeyRequired'))
+    return
+  }
+
+  testingTMDB.value = true
+  try {
+    await testServiceConnection({
+      type: 'themoviedb',
+      config: {
+        api_key: apiKey,
+      },
+    })
+    notification.success(t('common.connectionSuccess'))
+  } catch (error) {
+    console.error(t('settings.metadata.connectionTestFailed'), error)
+  } finally {
+    testingTMDB.value = false
+  }
+}
+
 const saveDouban = async () => {
   savingDouban.value = true
   try {
@@ -325,6 +370,21 @@ const saveDouban = async () => {
     notification.error(t('settings.system.saveFailed', { message: error.message || error }))
   } finally {
     savingDouban.value = false
+  }
+}
+
+const testDoubanConnection = async () => {
+  testingDouban.value = true
+  try {
+    await testServiceConnection({
+      type: 'douban',
+      config: {},
+    })
+    notification.success(t('common.connectionSuccess'))
+  } catch (error) {
+    console.error(t('settings.metadata.connectionTestFailed'), error)
+  } finally {
+    testingDouban.value = false
   }
 }
 </script>

--- a/frontend/src/i18n/locales/en-US.js
+++ b/frontend/src/i18n/locales/en-US.js
@@ -1843,6 +1843,9 @@ export default {
       browseSourceSaved: 'Browse and search source saved',
       tmdbSaved: 'TMDB configuration saved',
       doubanSaved: 'Douban configuration saved',
+      testConnection: 'Test connection',
+      tmdbApiKeyRequired: 'Enter the TMDB API key first',
+      connectionTestFailed: 'Data source connection test failed:',
     },
     system: {
       loadConfigFailed: 'Failed to fetch system config:',

--- a/frontend/src/i18n/locales/zh-CN.js
+++ b/frontend/src/i18n/locales/zh-CN.js
@@ -1844,6 +1844,9 @@ export default {
       browseSourceSaved: '浏览与搜索源已保存',
       tmdbSaved: 'TMDB 配置已保存',
       doubanSaved: '豆瓣配置已保存',
+      testConnection: '测试连接',
+      tmdbApiKeyRequired: '请先填写 TMDB API Key',
+      connectionTestFailed: '数据源连接测试失败:',
     },
     system: {
       loadConfigFailed: '获取系统配置失败:',


### PR DESCRIPTION
## Summary
- Add test connection actions to the TMDB and Douban metadata settings cards.
- Reuse the existing config test-connection endpoint with current form values.
- Add backend coverage for TMDB and Douban test-connection dispatch.

## Testing
- `./aethera.sh test-backend tests/test_config_test_connection.py`
- `./scripts/check_quality.sh`

## Notes
- The test action does not save settings. Users still need to click Save after a successful test.