### PR TITLE
Show complete task episode ranges

### DIFF
--- a/frontend/src/composables/useResourceTags.js
+++ b/frontend/src/composables/useResourceTags.js
@@ -1,4 +1,4 @@
-import { formatAbsoluteDateTime, formatRelativeTime } from '@/utils/formatters'
+import { formatAbsoluteDateTime, formatEpisodeRange, formatRelativeTime } from '@/utils/formatters'
 import { DEFAULT_RESOURCE_TAGS, ResourceTagType } from '@/constants/resourceTagTypes'
 import { useI18n } from 'vue-i18n'
 
@@ -398,7 +398,10 @@ export const useResourceTags = () => {
       return [`E${min}-E${max}`]
     }
 
-    return episodes.slice(0, 3).map(e => `E${e}`)
+    return formatEpisodeRange(episodeNumbers)
+      .split(',')
+      .filter(Boolean)
+      .map(range => `E${range}`)
   }
 
   const formatDiscLabel = (discNumber, discTotal) => {


### PR DESCRIPTION
## Summary

- replace the three-episode truncation used by resource tags
- compact selected episodes into complete contiguous ranges
- display non-contiguous selections such as `E7-E9` and `E11-E17`

## Root cause

The task list rendered only the first three episode tags whenever the selected episodes were not one continuous range, making a correct partial-file selection look incomplete.

## Validation

- `./scripts/review_with_gates.sh`
- Frontend quality checks passed
- ESLint passed
- Vite production build passed

## Risk

This reuses the existing episode-range formatter and changes presentation only; download selection data is unchanged.