### PR TITLE
Acknowledge recovered indexer alerts

### DIFF
--- a/backend/alembic/versions/0006_indexer_health_event_reopen.py
+++ b/backend/alembic/versions/0006_indexer_health_event_reopen.py
@@ -1,0 +1,39 @@
+"""Track indexer health event reopening.
+
+Revision ID: 0006_indexer_event_reopen
+Revises: 0005_indexer_notify_cooldown
+Create Date: 2026-08-04
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0006_indexer_event_reopen"
+down_revision = "0005_indexer_notify_cooldown"
+branch_labels = None
+depends_on = None
+
+
+def _has_table(table_name: str) -> bool:
+    bind = op.get_bind()
+    return sa.inspect(bind).has_table(table_name)
+
+
+def _has_column(table_name: str, column_name: str) -> bool:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    return any(column["name"] == column_name for column in inspector.get_columns(table_name))
+
+
+def upgrade() -> None:
+    if not _has_table("indexer_site_health") or _has_column("indexer_site_health", "last_reopened_at"):
+        return
+    op.add_column("indexer_site_health", sa.Column("last_reopened_at", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    if _has_table("indexer_site_health") and _has_column("indexer_site_health", "last_reopened_at"):
+        op.drop_column("indexer_site_health", "last_reopened_at")

--- a/backend/app/db/repositories/event_dispatch_repository.py
+++ b/backend/app/db/repositories/event_dispatch_repository.py
@@ -29,23 +29,27 @@ class EventDispatchRepository:
             }
         )
 
+    @staticmethod
+    def add_to_session(session, record: EventDispatchRecord) -> None:
+        session.add(
+            EventDispatchORM(
+                id=record.id,
+                event_id=record.event_id,
+                consumer_name=record.consumer_name,
+                status=record.status.value,
+                attempts=record.attempts,
+                max_attempts=record.max_attempts,
+                available_at=record.available_at.isoformat(),
+                error=record.error,
+                created_at=record.created_at.isoformat(),
+                started_at=record.started_at.isoformat() if record.started_at else None,
+                finished_at=record.finished_at.isoformat() if record.finished_at else None,
+            )
+        )
+
     async def insert(self, record: EventDispatchRecord) -> str:
         with SessionLocal() as session:
-            session.add(
-                EventDispatchORM(
-                    id=record.id,
-                    event_id=record.event_id,
-                    consumer_name=record.consumer_name,
-                    status=record.status.value,
-                    attempts=record.attempts,
-                    max_attempts=record.max_attempts,
-                    available_at=record.available_at.isoformat(),
-                    error=record.error,
-                    created_at=record.created_at.isoformat(),
-                    started_at=record.started_at.isoformat() if record.started_at else None,
-                    finished_at=record.finished_at.isoformat() if record.finished_at else None,
-                )
-            )
+            self.add_to_session(session, record)
             session.commit()
             return record.id
 

--- a/backend/app/db/repositories/event_repository.py
+++ b/backend/app/db/repositories/event_repository.py
@@ -17,6 +17,34 @@ from app.services.audit.search_text_support import build_event_search_text
 
 class EventRepository:
     @staticmethod
+    def add_to_session(session, event: Event) -> None:
+        session.add(
+            EventORM(
+                id=event.id,
+                ts=event.ts.isoformat(),
+                type=event.type.value,
+                level=event.level.value,
+                message_key=event.message_key,
+                message_params_json=event.message_params,
+                search_text=build_event_search_text(event),
+                media_id=str(event.media_id) if event.media_id else None,
+                media_season_number=event.media.season_number if event.media else None,
+                media_title=event.media_title,
+                media_year=event.media_year,
+                task_id=event.task_id,
+                subscription_id=event.subscription_id,
+                actor=event.actor.value if event.actor else None,
+                source=event.source.value if event.source else None,
+                addon_id=event.addon_id,
+                addon_name=event.addon_name,
+                entities_json=[item.model_dump(mode="json") for item in event.entities],
+                meta_json=EventRepository._meta_db_value(event.meta),
+                correlation_id=event.correlation_id,
+                action_id=event.action_id,
+            )
+        )
+
+    @staticmethod
     def _normalize_meta_text(raw) -> str:
         if raw is None or raw == "":
             return ""
@@ -127,31 +155,7 @@ class EventRepository:
 
     def insert(self, event: Event) -> str:
         with SessionLocal() as session:
-            session.add(
-                EventORM(
-                    id=event.id,
-                    ts=event.ts.isoformat(),
-                    type=event.type.value,
-                    level=event.level.value,
-                    message_key=event.message_key,
-                    message_params_json=event.message_params,
-                    search_text=build_event_search_text(event),
-                    media_id=str(event.media_id) if event.media_id else None,
-                    media_season_number=event.media.season_number if event.media else None,
-                    media_title=event.media_title,
-                    media_year=event.media_year,
-                    task_id=event.task_id,
-                    subscription_id=event.subscription_id,
-                    actor=event.actor.value if event.actor else None,
-                    source=event.source.value if event.source else None,
-                    addon_id=event.addon_id,
-                    addon_name=event.addon_name,
-                    entities_json=[item.model_dump(mode="json") for item in event.entities],
-                    meta_json=self._meta_db_value(event.meta),
-                    correlation_id=event.correlation_id,
-                    action_id=event.action_id,
-                )
-            )
+            self.add_to_session(session, event)
             session.commit()
             return event.id
 

--- a/backend/app/db/repositories/event_repository.py
+++ b/backend/app/db/repositories/event_repository.py
@@ -329,6 +329,39 @@ class EventRepository:
             session.commit()
             return int(result.rowcount or 0)
 
+    def acknowledge_matching_events(
+        self,
+        *,
+        correlation_id: str | None = None,
+        types: list[EventType] | None = None,
+        levels: list[EventLevel] | None = None,
+    ) -> int:
+        acknowledged_at = datetime.now().isoformat()
+        with SessionLocal() as session:
+            stmt = select(EventORM.id).where(
+                not_(
+                    select(EventAcknowledgementORM.event_id)
+                    .where(EventAcknowledgementORM.event_id == EventORM.id)
+                    .exists()
+                )
+            )
+            if correlation_id:
+                stmt = stmt.where(EventORM.correlation_id == correlation_id)
+            if types:
+                stmt = stmt.where(EventORM.type.in_([event_type.value for event_type in types]))
+            if levels:
+                stmt = stmt.where(EventORM.level.in_([level.value for level in levels]))
+            event_ids = session.execute(stmt).scalars().all()
+            if not event_ids:
+                return 0
+            result = session.execute(
+                sqlite_insert(EventAcknowledgementORM)
+                .values([{"event_id": event_id, "acknowledged_at": acknowledged_at} for event_id in event_ids])
+                .on_conflict_do_nothing(index_elements=[EventAcknowledgementORM.event_id])
+            )
+            session.commit()
+            return int(result.rowcount or 0)
+
     def prune_to_limit(self, max_records: int) -> int:
         limit = int(max_records or 0)
         if limit <= 0:

--- a/backend/app/db/repositories/indexer_site_health_repository.py
+++ b/backend/app/db/repositories/indexer_site_health_repository.py
@@ -66,6 +66,45 @@ class IndexerSiteHealthRepository:
             return status
 
     @staticmethod
+    def _apply_status(row: IndexerSiteHealthORM, status: IndexerSiteHealthStatus) -> None:
+        row.indexer_name = status.indexer_name or ""
+        row.site_name = status.site_name or ""
+        row.status = status.status
+        row.checked_at = status.checked_at.isoformat() if status.checked_at else None
+        row.last_success_at = status.last_success_at.isoformat() if status.last_success_at else None
+        row.last_failure_at = status.last_failure_at.isoformat() if status.last_failure_at else None
+        row.consecutive_failures = status.consecutive_failures
+        row.last_error_message = status.last_error_message
+        row.notify_pending = bool(status.notify_pending)
+        row.last_notified_at = status.last_notified_at.isoformat() if status.last_notified_at else None
+        row.last_reopened_at = status.last_reopened_at.isoformat() if status.last_reopened_at else None
+        row.client_type = status.client_type
+
+    def upsert_if_current(
+        self,
+        status: IndexerSiteHealthStatus,
+        expected: IndexerSiteHealthStatus | None,
+    ) -> tuple[bool, IndexerSiteHealthStatus]:
+        with SessionLocal() as session:
+            session.execute(text("BEGIN IMMEDIATE"))
+            row = session.get(
+                IndexerSiteHealthORM,
+                {"indexer_id": status.indexer_id, "site_id": status.site_id},
+            )
+            expected_matches = row is None if expected is None else self._matches_outcome(row, expected)
+            if not expected_matches:
+                session.rollback()
+                if row is None:
+                    return False, status
+                return False, self._to_model(row)
+            if row is None:
+                row = IndexerSiteHealthORM(indexer_id=status.indexer_id, site_id=status.site_id)
+                session.add(row)
+            self._apply_status(row, status)
+            session.commit()
+            return True, status
+
+    @staticmethod
     def _matches_outcome(row: IndexerSiteHealthORM | None, status: IndexerSiteHealthStatus) -> bool:
         checked_at = status.checked_at.isoformat() if status.checked_at else None
         return bool(
@@ -166,6 +205,7 @@ class IndexerSiteHealthRepository:
         self,
         status: IndexerSiteHealthStatus,
         correlation_id: str,
+        fallback_event: Event,
     ) -> tuple[bool, int]:
         with SessionLocal() as session:
             session.execute(text("BEGIN IMMEDIATE"))
@@ -184,6 +224,9 @@ class IndexerSiteHealthRepository:
                     delete(EventAcknowledgementORM).where(EventAcknowledgementORM.event_id == event_id)
                 )
                 reopened_count = int(result.rowcount or 0)
+            else:
+                EventRepository.add_to_session(session, fallback_event)
+                reopened_count = 1
             row.last_reopened_at = status.checked_at.isoformat() if status.checked_at else datetime.now().isoformat()
             session.commit()
             return True, reopened_count

--- a/backend/app/db/repositories/indexer_site_health_repository.py
+++ b/backend/app/db/repositories/indexer_site_health_repository.py
@@ -7,8 +7,9 @@ from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 
 from app.db.sql.models import EventAcknowledgementORM, EventORM, IndexerSiteHealthORM
 from app.db.sql.session import SessionLocal
+from app.db.repositories.event_repository import EventRepository
 from app.schemas.constants.event_types import EventTypes
-from app.schemas.domain.event import EventLevel
+from app.schemas.domain.event import Event, EventLevel
 from app.schemas.runtime.indexer_site_health import IndexerSiteHealthStatus
 
 
@@ -95,9 +96,10 @@ class IndexerSiteHealthRepository:
             .limit(1)
         ).scalar_one_or_none()
 
-    def mark_unhealthy_event_emitted(
+    def emit_unhealthy_event_if_current(
         self,
         status: IndexerSiteHealthStatus,
+        event: Event,
         notified_at: datetime,
     ) -> bool:
         with SessionLocal() as session:
@@ -109,6 +111,7 @@ class IndexerSiteHealthRepository:
             if not self._matches_outcome(row, status) or row.status != "unhealthy" or not row.notify_pending:
                 session.rollback()
                 return False
+            EventRepository.add_to_session(session, event)
             row.last_notified_at = notified_at.isoformat()
             session.commit()
             return True

--- a/backend/app/db/repositories/indexer_site_health_repository.py
+++ b/backend/app/db/repositories/indexer_site_health_repository.py
@@ -29,6 +29,7 @@ class IndexerSiteHealthRepository:
                 "last_error_message": row.last_error_message,
                 "notify_pending": bool(row.notify_pending),
                 "last_notified_at": row.last_notified_at,
+                "last_reopened_at": row.last_reopened_at,
                 "client_type": row.client_type,
             }
         )
@@ -58,6 +59,7 @@ class IndexerSiteHealthRepository:
             row.last_error_message = status.last_error_message
             row.notify_pending = bool(status.notify_pending)
             row.last_notified_at = status.last_notified_at.isoformat() if status.last_notified_at else None
+            row.last_reopened_at = status.last_reopened_at.isoformat() if status.last_reopened_at else None
             row.client_type = status.client_type
             session.commit()
             return status
@@ -81,6 +83,35 @@ class IndexerSiteHealthRepository:
                 .where(EventORM.level == EventLevel.warning.value)
             ).scalars().all()
         )
+
+    @staticmethod
+    def _latest_unhealthy_event_id(session, correlation_id: str) -> str | None:
+        return session.execute(
+            select(EventORM.id)
+            .where(EventORM.correlation_id == correlation_id)
+            .where(EventORM.type == EventTypes.INDEXER_SITE_UNHEALTHY.value)
+            .where(EventORM.level == EventLevel.warning.value)
+            .order_by(EventORM.ts.desc(), EventORM.id.desc())
+            .limit(1)
+        ).scalar_one_or_none()
+
+    def mark_unhealthy_event_emitted(
+        self,
+        status: IndexerSiteHealthStatus,
+        notified_at: datetime,
+    ) -> bool:
+        with SessionLocal() as session:
+            session.execute(text("BEGIN IMMEDIATE"))
+            row = session.get(
+                IndexerSiteHealthORM,
+                {"indexer_id": status.indexer_id, "site_id": status.site_id},
+            )
+            if not self._matches_outcome(row, status) or row.status != "unhealthy" or not row.notify_pending:
+                session.rollback()
+                return False
+            row.last_notified_at = notified_at.isoformat()
+            session.commit()
+            return True
 
     def acknowledge_recovered_unhealthy_events(
         self,
@@ -143,13 +174,14 @@ class IndexerSiteHealthRepository:
                 session.rollback()
                 return False, 0
 
-            event_ids = self._matching_unhealthy_event_ids(session, correlation_id)
+            event_id = self._latest_unhealthy_event_id(session, correlation_id)
             reopened_count = 0
-            if event_ids:
+            if event_id:
                 result = session.execute(
-                    delete(EventAcknowledgementORM).where(EventAcknowledgementORM.event_id.in_(event_ids))
+                    delete(EventAcknowledgementORM).where(EventAcknowledgementORM.event_id == event_id)
                 )
                 reopened_count = int(result.rowcount or 0)
+            row.last_reopened_at = status.checked_at.isoformat() if status.checked_at else datetime.now().isoformat()
             session.commit()
             return True, reopened_count
 

--- a/backend/app/db/repositories/indexer_site_health_repository.py
+++ b/backend/app/db/repositories/indexer_site_health_repository.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
-from sqlalchemy import select
+from datetime import datetime
 
-from app.db.sql.models import IndexerSiteHealthORM
+from sqlalchemy import delete, not_, select, text
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+
+from app.db.sql.models import EventAcknowledgementORM, EventORM, IndexerSiteHealthORM
 from app.db.sql.session import SessionLocal
+from app.schemas.constants.event_types import EventTypes
+from app.schemas.domain.event import EventLevel
 from app.schemas.runtime.indexer_site_health import IndexerSiteHealthStatus
 
 
@@ -56,6 +61,97 @@ class IndexerSiteHealthRepository:
             row.client_type = status.client_type
             session.commit()
             return status
+
+    @staticmethod
+    def _matches_outcome(row: IndexerSiteHealthORM | None, status: IndexerSiteHealthStatus) -> bool:
+        checked_at = status.checked_at.isoformat() if status.checked_at else None
+        return bool(
+            row
+            and row.status == status.status
+            and row.checked_at == checked_at
+        )
+
+    @staticmethod
+    def _matching_unhealthy_event_ids(session, correlation_id: str) -> list[str]:
+        return list(
+            session.execute(
+                select(EventORM.id)
+                .where(EventORM.correlation_id == correlation_id)
+                .where(EventORM.type == EventTypes.INDEXER_SITE_UNHEALTHY.value)
+                .where(EventORM.level == EventLevel.warning.value)
+            ).scalars().all()
+        )
+
+    def acknowledge_recovered_unhealthy_events(
+        self,
+        status: IndexerSiteHealthStatus,
+        correlation_id: str,
+    ) -> tuple[bool, int]:
+        with SessionLocal() as session:
+            session.execute(text("BEGIN IMMEDIATE"))
+            row = session.get(
+                IndexerSiteHealthORM,
+                {"indexer_id": status.indexer_id, "site_id": status.site_id},
+            )
+            if not self._matches_outcome(row, status) or row.status != "healthy" or not row.notify_pending:
+                session.rollback()
+                return False, 0
+
+            event_ids = self._matching_unhealthy_event_ids(session, correlation_id)
+            unacknowledged_ids = list(
+                session.execute(
+                    select(EventORM.id)
+                    .where(EventORM.id.in_(event_ids))
+                    .where(
+                        not_(
+                            select(EventAcknowledgementORM.event_id)
+                            .where(EventAcknowledgementORM.event_id == EventORM.id)
+                            .exists()
+                        )
+                    )
+                ).scalars().all()
+            ) if event_ids else []
+            acknowledged_count = 0
+            if unacknowledged_ids:
+                result = session.execute(
+                    sqlite_insert(EventAcknowledgementORM)
+                    .values(
+                        [
+                            {"event_id": event_id, "acknowledged_at": datetime.now().isoformat()}
+                            for event_id in unacknowledged_ids
+                        ]
+                    )
+                    .on_conflict_do_nothing(index_elements=[EventAcknowledgementORM.event_id])
+                )
+                acknowledged_count = int(result.rowcount or 0)
+            row.notify_pending = False
+            session.commit()
+            return True, acknowledged_count
+
+    def reopen_unhealthy_events(
+        self,
+        status: IndexerSiteHealthStatus,
+        correlation_id: str,
+    ) -> tuple[bool, int]:
+        with SessionLocal() as session:
+            session.execute(text("BEGIN IMMEDIATE"))
+            row = session.get(
+                IndexerSiteHealthORM,
+                {"indexer_id": status.indexer_id, "site_id": status.site_id},
+            )
+            if not self._matches_outcome(row, status) or row.status != "unhealthy" or not row.notify_pending:
+                session.rollback()
+                return False, 0
+
+            event_ids = self._matching_unhealthy_event_ids(session, correlation_id)
+            reopened_count = 0
+            if event_ids:
+                result = session.execute(
+                    delete(EventAcknowledgementORM).where(EventAcknowledgementORM.event_id.in_(event_ids))
+                )
+                reopened_count = int(result.rowcount or 0)
+            session.commit()
+            return True, reopened_count
 
     def list_by_indexer(self, indexer_id: str) -> list[IndexerSiteHealthStatus]:
         with SessionLocal() as session:

--- a/backend/app/db/repositories/indexer_site_health_repository.py
+++ b/backend/app/db/repositories/indexer_site_health_repository.py
@@ -8,8 +8,10 @@ from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from app.db.sql.models import EventAcknowledgementORM, EventORM, IndexerSiteHealthORM
 from app.db.sql.session import SessionLocal
 from app.db.repositories.event_repository import EventRepository
+from app.db.repositories.event_dispatch_repository import EventDispatchRepository
 from app.schemas.constants.event_types import EventTypes
 from app.schemas.domain.event import Event, EventLevel
+from app.schemas.persistence.event_dispatch import EventDispatchRecord
 from app.schemas.runtime.indexer_site_health import IndexerSiteHealthStatus
 
 
@@ -149,6 +151,7 @@ class IndexerSiteHealthRepository:
         self,
         status: IndexerSiteHealthStatus,
         event: Event,
+        dispatch_records: list[EventDispatchRecord],
         notified_at: datetime,
     ) -> bool:
         with SessionLocal() as session:
@@ -161,6 +164,8 @@ class IndexerSiteHealthRepository:
                 session.rollback()
                 return False
             EventRepository.add_to_session(session, event)
+            for dispatch_record in dispatch_records:
+                EventDispatchRepository.add_to_session(session, dispatch_record)
             row.last_notified_at = notified_at.isoformat()
             session.commit()
             return True

--- a/backend/app/db/repositories/indexer_site_health_repository.py
+++ b/backend/app/db/repositories/indexer_site_health_repository.py
@@ -106,11 +106,21 @@ class IndexerSiteHealthRepository:
 
     @staticmethod
     def _matches_outcome(row: IndexerSiteHealthORM | None, status: IndexerSiteHealthStatus) -> bool:
-        checked_at = status.checked_at.isoformat() if status.checked_at else None
+        def iso(value):
+            return value.isoformat() if value else None
+
         return bool(
             row
             and row.status == status.status
-            and row.checked_at == checked_at
+            and row.checked_at == iso(status.checked_at)
+            and row.last_success_at == iso(status.last_success_at)
+            and row.last_failure_at == iso(status.last_failure_at)
+            and row.consecutive_failures == status.consecutive_failures
+            and row.last_error_message == status.last_error_message
+            and bool(row.notify_pending) == status.notify_pending
+            and row.last_notified_at == iso(status.last_notified_at)
+            and row.last_reopened_at == iso(status.last_reopened_at)
+            and row.client_type == status.client_type
         )
 
     @staticmethod

--- a/backend/app/db/sql/models.py
+++ b/backend/app/db/sql/models.py
@@ -441,6 +441,7 @@ class IndexerSiteHealthORM(Base):
     last_error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
     notify_pending: Mapped[bool] = mapped_column(Integer, nullable=False, default=0)
     last_notified_at: Mapped[str | None] = mapped_column(Text, nullable=True)
+    last_reopened_at: Mapped[str | None] = mapped_column(Text, nullable=True)
     client_type: Mapped[str] = mapped_column(Text, nullable=False, default="jackett")
 
     __table_args__ = (

--- a/backend/app/schemas/runtime/indexer_site_health.py
+++ b/backend/app/schemas/runtime/indexer_site_health.py
@@ -17,6 +17,7 @@ class IndexerSiteHealthStatus(BaseModel):
     last_error_message: Optional[str] = None
     notify_pending: bool = False
     last_notified_at: Optional[datetime] = None
+    last_reopened_at: Optional[datetime] = None
     client_type: str = "jackett"
 
 

--- a/backend/app/services/application/events/dispatch.py
+++ b/backend/app/services/application/events/dispatch.py
@@ -19,14 +19,19 @@ class EventDispatchService:
         self._event_repo = EventRepository()
         self.max_terminal_dispatches = 20000
 
-    async def enqueue_event(self, event_id: str, event_type: str) -> None:
-        consumers = event_consumer_service.match_consumers(event_type)
-        for consumer in consumers:
-            record = EventDispatchRecord(
+    @staticmethod
+    def build_records(event_id: str, event_type: str) -> list[EventDispatchRecord]:
+        return [
+            EventDispatchRecord(
                 id=str(uuid.uuid4()),
                 event_id=event_id,
                 consumer_name=consumer.name,
             )
+            for consumer in event_consumer_service.match_consumers(event_type)
+        ]
+
+    async def enqueue_event(self, event_id: str, event_type: str) -> None:
+        for record in self.build_records(event_id, event_type):
             await self.repo.insert(record)
 
     async def reset_running_dispatches(self) -> None:

--- a/backend/app/services/audit/event_service.py
+++ b/backend/app/services/audit/event_service.py
@@ -21,6 +21,7 @@ from app.schemas.domain.event import (
     EventType,
     MediaEventCreate,
 )
+from app.schemas.persistence.event_dispatch import EventDispatchRecord
 from app.services.application.events.dispatch import event_dispatch_service
 from app.services.audit.action_catalog import ACTION_NAME_NOTIFICATION_SEND
 from app.services.audit.action_service import action_service
@@ -78,6 +79,11 @@ class EventService:
                 asyncio.run(event_dispatch_service.enqueue_event(event.id, event.type))
             else:
                 loop.create_task(event_dispatch_service.enqueue_event(event.id, event.type))
+
+    def build_dispatch_records(self, event: Event) -> list[EventDispatchRecord]:
+        if not self.is_business_event(event.type):
+            return []
+        return event_dispatch_service.build_records(event.id, event.type)
 
     def build_event(
         self,

--- a/backend/app/services/audit/event_service.py
+++ b/backend/app/services/audit/event_service.py
@@ -265,6 +265,19 @@ class EventService:
     def acknowledge_attention_events(self) -> int:
         return self.repo.acknowledge_attention_events()
 
+    def acknowledge_matching_events(
+        self,
+        *,
+        correlation_id: str | None = None,
+        types: list[EventType] | None = None,
+        levels: list[EventLevel] | None = None,
+    ) -> int:
+        return self.repo.acknowledge_matching_events(
+            correlation_id=correlation_id,
+            types=types,
+            levels=levels,
+        )
+
     def list_filter_options(
         self,
         media_id: MediaID | None = None,

--- a/backend/app/services/audit/event_service.py
+++ b/backend/app/services/audit/event_service.py
@@ -67,6 +67,10 @@ class EventService:
 
     def _persist_event(self, event: Event) -> Event:
         self.repo.insert(event)
+        self.dispatch_persisted_event(event)
+        return event
+
+    def dispatch_persisted_event(self, event: Event) -> None:
         if self.is_business_event(event.type):
             try:
                 loop = asyncio.get_running_loop()
@@ -74,15 +78,13 @@ class EventService:
                 asyncio.run(event_dispatch_service.enqueue_event(event.id, event.type))
             else:
                 loop.create_task(event_dispatch_service.enqueue_event(event.id, event.type))
-        return event
 
-    def emit(
+    def build_event(
         self,
         event: EventCreate,
         meta: BaseModel | None = None,
-    ) -> Event | None:
-        # Internal note.
-        ev = Event(
+    ) -> Event:
+        return Event(
             type=event.type,
             message_key=event.message_key or event_message_key(event.type),
             message_params=_merge_message_params(event, meta),
@@ -99,6 +101,14 @@ class EventService:
             correlation_id=event.correlation_id,
             action_id=event.action_id or get_current_action_id(),
         )
+
+    def emit(
+        self,
+        event: EventCreate,
+        meta: BaseModel | None = None,
+    ) -> Event | None:
+        # Internal note.
+        ev = self.build_event(event, meta)
         return self._persist_event(ev)
 
     def emit_media(

--- a/backend/app/services/config/indexer_client_settings.py
+++ b/backend/app/services/config/indexer_client_settings.py
@@ -34,9 +34,13 @@ class IndexerSiteHealthState:
     def _unhealthy_event_correlation_id(indexer_id: str, site_id: str) -> str:
         return f"indexer:{indexer_id}:site:{site_id}:unhealthy"
 
-    def _emit_unhealthy_event(self, status: IndexerSiteHealthStatus) -> bool:
+    def _emit_unhealthy_event(
+        self,
+        status: IndexerSiteHealthStatus,
+        notified_at: datetime,
+    ) -> bool:
         try:
-            event_service.emit(
+            event = event_service.build_event(
                 EventCreate(
                     type=EventTypes.INDEXER_SITE_UNHEALTHY,
                     level=EventLevel.warning,
@@ -57,6 +61,10 @@ class IndexerSiteHealthState:
                     correlation_id=self._unhealthy_event_correlation_id(status.indexer_id, status.site_id),
                 )
             )
+            applied = self._repo.emit_unhealthy_event_if_current(status, event, notified_at)
+            if not applied:
+                return False
+            event_service.dispatch_persisted_event(event)
             return True
         except Exception as exc:
             logger.error(
@@ -84,22 +92,6 @@ class IndexerSiteHealthState:
         except Exception as exc:
             logger.error(
                 "Failed to acknowledge recovered indexer site unhealthy events for %s/%s: %s",
-                status.indexer_id,
-                status.site_id,
-                exc,
-            )
-            return False
-
-    def _mark_unhealthy_event_emitted(
-        self,
-        status: IndexerSiteHealthStatus,
-        notified_at: datetime,
-    ) -> bool:
-        try:
-            return self._repo.mark_unhealthy_event_emitted(status, notified_at)
-        except Exception as exc:
-            logger.error(
-                "Failed to finalize indexer site unhealthy event for %s/%s: %s",
                 status.indexer_id,
                 status.site_id,
                 exc,
@@ -230,8 +222,8 @@ class IndexerSiteHealthState:
             client_type=client_type,
         )
         saved = self._upsert(status)
-        if should_emit and self._emit_unhealthy_event(saved):
-            self._mark_unhealthy_event_emitted(saved, now)
+        if should_emit:
+            self._emit_unhealthy_event(saved, now)
         elif should_reopen:
             self._reopen_unhealthy_event(saved)
         return self._get_record(indexer_id, site_id) or saved

--- a/backend/app/services/config/indexer_client_settings.py
+++ b/backend/app/services/config/indexer_client_settings.py
@@ -30,6 +30,10 @@ class IndexerSiteHealthState:
     def _upsert(self, status: IndexerSiteHealthStatus) -> IndexerSiteHealthStatus:
         return self._repo.upsert(status)
 
+    @staticmethod
+    def _unhealthy_event_correlation_id(indexer_id: str, site_id: str) -> str:
+        return f"indexer:{indexer_id}:site:{site_id}:unhealthy"
+
     def _emit_unhealthy_event(self, status: IndexerSiteHealthStatus) -> bool:
         try:
             event_service.emit(
@@ -50,7 +54,7 @@ class IndexerSiteHealthState:
                         EventEntityRef(type="indexer", id=status.indexer_id),
                         EventEntityRef(type="indexer_site", id=status.site_id),
                     ],
-                    correlation_id=f"indexer:{status.indexer_id}:site:{status.site_id}:unhealthy",
+                    correlation_id=self._unhealthy_event_correlation_id(status.indexer_id, status.site_id),
                 )
             )
             return True
@@ -62,6 +66,28 @@ class IndexerSiteHealthState:
                 exc,
             )
             return False
+
+    def _acknowledge_unhealthy_event(self, status: IndexerSiteHealthStatus) -> None:
+        try:
+            acknowledged_count = event_service.acknowledge_matching_events(
+                correlation_id=self._unhealthy_event_correlation_id(status.indexer_id, status.site_id),
+                types=[EventTypes.INDEXER_SITE_UNHEALTHY],
+                levels=[EventLevel.warning],
+            )
+            if acknowledged_count:
+                logger.info(
+                    "Acknowledged recovered indexer site unhealthy events: indexer=%s site=%s count=%s",
+                    status.indexer_id,
+                    status.site_id,
+                    acknowledged_count,
+                )
+        except Exception as exc:
+            logger.error(
+                "Failed to acknowledge recovered indexer site unhealthy events for %s/%s: %s",
+                status.indexer_id,
+                status.site_id,
+                exc,
+            )
 
     def record_outcomes(self, outcomes: list[IndexerSiteSearchOutcome]) -> None:
         for outcome in outcomes:
@@ -94,6 +120,9 @@ class IndexerSiteHealthState:
     ) -> IndexerSiteHealthStatus:
         current = self._get_record(indexer_id, site_id)
         now = datetime.now()
+        should_acknowledge_unhealthy_event = bool(
+            current and (current.status == "unhealthy" or current.notify_pending)
+        )
         status = IndexerSiteHealthStatus(
             indexer_id=indexer_id,
             indexer_name=indexer_name,
@@ -109,7 +138,10 @@ class IndexerSiteHealthState:
             last_notified_at=current.last_notified_at if current else None,
             client_type=client_type,
         )
-        return self._upsert(status)
+        saved = self._upsert(status)
+        if should_acknowledge_unhealthy_event:
+            self._acknowledge_unhealthy_event(saved)
+        return saved
 
     def record_failure(
         self,

--- a/backend/app/services/config/indexer_client_settings.py
+++ b/backend/app/services/config/indexer_client_settings.py
@@ -90,6 +90,22 @@ class IndexerSiteHealthState:
             )
             return False
 
+    def _mark_unhealthy_event_emitted(
+        self,
+        status: IndexerSiteHealthStatus,
+        notified_at: datetime,
+    ) -> bool:
+        try:
+            return self._repo.mark_unhealthy_event_emitted(status, notified_at)
+        except Exception as exc:
+            logger.error(
+                "Failed to finalize indexer site unhealthy event for %s/%s: %s",
+                status.indexer_id,
+                status.site_id,
+                exc,
+            )
+            return False
+
     def _reopen_unhealthy_event(self, status: IndexerSiteHealthStatus) -> None:
         try:
             applied, reopened_count = self._repo.reopen_unhealthy_events(
@@ -158,6 +174,7 @@ class IndexerSiteHealthState:
             last_error_message=None,
             notify_pending=should_acknowledge_unhealthy_event,
             last_notified_at=current.last_notified_at if current else None,
+            last_reopened_at=current.last_reopened_at if current else None,
             client_type=client_type,
         )
         saved = self._upsert(status)
@@ -191,6 +208,10 @@ class IndexerSiteHealthState:
             and current.last_success_at
             and current.last_notified_at
             and current.last_success_at > current.last_notified_at
+            and (
+                current.last_reopened_at is None
+                or current.last_success_at > current.last_reopened_at
+            )
         )
         status = IndexerSiteHealthStatus(
             indexer_id=indexer_id,
@@ -205,15 +226,15 @@ class IndexerSiteHealthState:
             last_error_message=error_message,
             notify_pending=consecutive_failures >= INDEXER_SITE_FAILURE_NOTIFY_THRESHOLD,
             last_notified_at=current.last_notified_at if current else None,
+            last_reopened_at=current.last_reopened_at if current else None,
             client_type=client_type,
         )
         saved = self._upsert(status)
         if should_emit and self._emit_unhealthy_event(saved):
-            saved.last_notified_at = now
-            saved = self._upsert(saved)
+            self._mark_unhealthy_event_emitted(saved, now)
         elif should_reopen:
             self._reopen_unhealthy_event(saved)
-        return saved
+        return self._get_record(indexer_id, site_id) or saved
 
     @staticmethod
     def _notify_cooldown_elapsed(last_notified_at: datetime | None, now: datetime) -> bool:

--- a/backend/app/services/config/indexer_client_settings.py
+++ b/backend/app/services/config/indexer_client_settings.py
@@ -67,12 +67,11 @@ class IndexerSiteHealthState:
             )
             return False
 
-    def _acknowledge_unhealthy_event(self, status: IndexerSiteHealthStatus) -> None:
+    def _acknowledge_unhealthy_event(self, status: IndexerSiteHealthStatus) -> bool:
         try:
-            acknowledged_count = event_service.acknowledge_matching_events(
-                correlation_id=self._unhealthy_event_correlation_id(status.indexer_id, status.site_id),
-                types=[EventTypes.INDEXER_SITE_UNHEALTHY],
-                levels=[EventLevel.warning],
+            applied, acknowledged_count = self._repo.acknowledge_recovered_unhealthy_events(
+                status,
+                self._unhealthy_event_correlation_id(status.indexer_id, status.site_id),
             )
             if acknowledged_count:
                 logger.info(
@@ -81,9 +80,32 @@ class IndexerSiteHealthState:
                     status.site_id,
                     acknowledged_count,
                 )
+            return applied
         except Exception as exc:
             logger.error(
                 "Failed to acknowledge recovered indexer site unhealthy events for %s/%s: %s",
+                status.indexer_id,
+                status.site_id,
+                exc,
+            )
+            return False
+
+    def _reopen_unhealthy_event(self, status: IndexerSiteHealthStatus) -> None:
+        try:
+            applied, reopened_count = self._repo.reopen_unhealthy_events(
+                status,
+                self._unhealthy_event_correlation_id(status.indexer_id, status.site_id),
+            )
+            if applied and reopened_count:
+                logger.info(
+                    "Reopened recurring indexer site unhealthy events: indexer=%s site=%s count=%s",
+                    status.indexer_id,
+                    status.site_id,
+                    reopened_count,
+                )
+        except Exception as exc:
+            logger.error(
+                "Failed to reopen recurring indexer site unhealthy events for %s/%s: %s",
                 status.indexer_id,
                 status.site_id,
                 exc,
@@ -134,13 +156,14 @@ class IndexerSiteHealthState:
             last_failure_at=current.last_failure_at if current else None,
             consecutive_failures=0,
             last_error_message=None,
-            notify_pending=False,
+            notify_pending=should_acknowledge_unhealthy_event,
             last_notified_at=current.last_notified_at if current else None,
             client_type=client_type,
         )
         saved = self._upsert(status)
         if should_acknowledge_unhealthy_event:
             self._acknowledge_unhealthy_event(saved)
+            return self._get_record(indexer_id, site_id) or saved
         return saved
 
     def record_failure(
@@ -161,6 +184,14 @@ class IndexerSiteHealthState:
             consecutive_failures >= INDEXER_SITE_FAILURE_NOTIFY_THRESHOLD
             and self._notify_cooldown_elapsed(current.last_notified_at if current else None, now)
         )
+        should_reopen = bool(
+            consecutive_failures >= INDEXER_SITE_FAILURE_NOTIFY_THRESHOLD
+            and not should_emit
+            and current
+            and current.last_success_at
+            and current.last_notified_at
+            and current.last_success_at > current.last_notified_at
+        )
         status = IndexerSiteHealthStatus(
             indexer_id=indexer_id,
             indexer_name=indexer_name,
@@ -180,6 +211,8 @@ class IndexerSiteHealthState:
         if should_emit and self._emit_unhealthy_event(saved):
             saved.last_notified_at = now
             saved = self._upsert(saved)
+        elif should_reopen:
+            self._reopen_unhealthy_event(saved)
         return saved
 
     @staticmethod

--- a/backend/app/services/config/indexer_client_settings.py
+++ b/backend/app/services/config/indexer_client_settings.py
@@ -199,44 +199,48 @@ class IndexerSiteHealthState:
         client_type: str = "jackett",
     ) -> IndexerSiteHealthStatus:
         current = self._get_record(indexer_id, site_id)
-        now = datetime.now()
-        previous_failures = current.consecutive_failures if current else 0
-        consecutive_failures = previous_failures + 1
-        should_emit = (
-            consecutive_failures >= INDEXER_SITE_FAILURE_NOTIFY_THRESHOLD
-            and self._notify_cooldown_elapsed(current.last_notified_at if current else None, now)
-        )
-        should_reopen = bool(
-            consecutive_failures >= INDEXER_SITE_FAILURE_NOTIFY_THRESHOLD
-            and not should_emit
-            and current
-            and current.last_success_at
-            and current.last_notified_at
-            and current.last_success_at > current.last_notified_at
-            and (
-                current.last_reopened_at is None
-                or current.last_success_at > current.last_reopened_at
+        while True:
+            now = datetime.now()
+            if current and current.checked_at and now <= current.checked_at:
+                now = current.checked_at + timedelta(microseconds=1)
+            previous_failures = current.consecutive_failures if current else 0
+            consecutive_failures = previous_failures + 1
+            should_emit = (
+                consecutive_failures >= INDEXER_SITE_FAILURE_NOTIFY_THRESHOLD
+                and self._notify_cooldown_elapsed(current.last_notified_at if current else None, now)
             )
-        )
-        status = IndexerSiteHealthStatus(
-            indexer_id=indexer_id,
-            indexer_name=indexer_name,
-            site_id=site_id,
-            site_name=site_name,
-            status="unhealthy",
-            checked_at=now,
-            last_success_at=current.last_success_at if current else None,
-            last_failure_at=now,
-            consecutive_failures=consecutive_failures,
-            last_error_message=error_message,
-            notify_pending=consecutive_failures >= INDEXER_SITE_FAILURE_NOTIFY_THRESHOLD,
-            last_notified_at=current.last_notified_at if current else None,
-            last_reopened_at=current.last_reopened_at if current else None,
-            client_type=client_type,
-        )
-        applied, saved = self._upsert_if_current(status, current)
-        if not applied:
-            return saved
+            should_reopen = bool(
+                consecutive_failures >= INDEXER_SITE_FAILURE_NOTIFY_THRESHOLD
+                and not should_emit
+                and current
+                and current.last_success_at
+                and current.last_notified_at
+                and current.last_success_at > current.last_notified_at
+                and (
+                    current.last_reopened_at is None
+                    or current.last_success_at > current.last_reopened_at
+                )
+            )
+            status = IndexerSiteHealthStatus(
+                indexer_id=indexer_id,
+                indexer_name=indexer_name,
+                site_id=site_id,
+                site_name=site_name,
+                status="unhealthy",
+                checked_at=now,
+                last_success_at=current.last_success_at if current else None,
+                last_failure_at=now,
+                consecutive_failures=consecutive_failures,
+                last_error_message=error_message,
+                notify_pending=consecutive_failures >= INDEXER_SITE_FAILURE_NOTIFY_THRESHOLD,
+                last_notified_at=current.last_notified_at if current else None,
+                last_reopened_at=current.last_reopened_at if current else None,
+                client_type=client_type,
+            )
+            applied, saved = self._upsert_if_current(status, current)
+            if applied:
+                break
+            current = saved
         if should_emit:
             self._emit_unhealthy_event(saved, now)
         elif should_reopen:

--- a/backend/app/services/config/indexer_client_settings.py
+++ b/backend/app/services/config/indexer_client_settings.py
@@ -8,7 +8,7 @@ from app.db.repositories.indexer_site_health_repository import IndexerSiteHealth
 from app.db.repositories.settings_sqlite_repository import SettingsSqliteRepository
 from app.schemas.config import IndexerConfig, IndexerProviderConfig
 from app.schemas.constants.event_types import EventTypes
-from app.schemas.domain.event import EventCreate, EventEntityRef, EventLevel, EventSource
+from app.schemas.domain.event import Event, EventCreate, EventEntityRef, EventLevel, EventSource
 from app.schemas.exception import ConfigurationException
 from app.schemas.runtime.indexer_runtime import IndexerSiteSearchOutcome
 from app.schemas.runtime.indexer_site_health import IndexerSiteHealthStatus
@@ -30,9 +30,39 @@ class IndexerSiteHealthState:
     def _upsert(self, status: IndexerSiteHealthStatus) -> IndexerSiteHealthStatus:
         return self._repo.upsert(status)
 
+    def _upsert_if_current(
+        self,
+        status: IndexerSiteHealthStatus,
+        expected: IndexerSiteHealthStatus | None,
+    ) -> tuple[bool, IndexerSiteHealthStatus]:
+        return self._repo.upsert_if_current(status, expected)
+
     @staticmethod
     def _unhealthy_event_correlation_id(indexer_id: str, site_id: str) -> str:
         return f"indexer:{indexer_id}:site:{site_id}:unhealthy"
+
+    def _build_unhealthy_event(self, status: IndexerSiteHealthStatus) -> Event:
+        return event_service.build_event(
+            EventCreate(
+                type=EventTypes.INDEXER_SITE_UNHEALTHY,
+                level=EventLevel.warning,
+                source=EventSource.base,
+                message_params={
+                    "indexer_id": status.indexer_id,
+                    "indexer_name": status.indexer_name,
+                    "site_id": status.site_id,
+                    "site_name": status.site_name,
+                    "client_type": status.client_type,
+                    "consecutive_failures": str(status.consecutive_failures),
+                    "error": status.last_error_message or "",
+                },
+                entities=[
+                    EventEntityRef(type="indexer", id=status.indexer_id),
+                    EventEntityRef(type="indexer_site", id=status.site_id),
+                ],
+                correlation_id=self._unhealthy_event_correlation_id(status.indexer_id, status.site_id),
+            )
+        )
 
     def _emit_unhealthy_event(
         self,
@@ -40,27 +70,7 @@ class IndexerSiteHealthState:
         notified_at: datetime,
     ) -> bool:
         try:
-            event = event_service.build_event(
-                EventCreate(
-                    type=EventTypes.INDEXER_SITE_UNHEALTHY,
-                    level=EventLevel.warning,
-                    source=EventSource.base,
-                    message_params={
-                        "indexer_id": status.indexer_id,
-                        "indexer_name": status.indexer_name,
-                        "site_id": status.site_id,
-                        "site_name": status.site_name,
-                        "client_type": status.client_type,
-                        "consecutive_failures": str(status.consecutive_failures),
-                        "error": status.last_error_message or "",
-                    },
-                    entities=[
-                        EventEntityRef(type="indexer", id=status.indexer_id),
-                        EventEntityRef(type="indexer_site", id=status.site_id),
-                    ],
-                    correlation_id=self._unhealthy_event_correlation_id(status.indexer_id, status.site_id),
-                )
-            )
+            event = self._build_unhealthy_event(status)
             applied = self._repo.emit_unhealthy_event_if_current(status, event, notified_at)
             if not applied:
                 return False
@@ -103,6 +113,7 @@ class IndexerSiteHealthState:
             applied, reopened_count = self._repo.reopen_unhealthy_events(
                 status,
                 self._unhealthy_event_correlation_id(status.indexer_id, status.site_id),
+                self._build_unhealthy_event(status),
             )
             if applied and reopened_count:
                 logger.info(
@@ -169,7 +180,9 @@ class IndexerSiteHealthState:
             last_reopened_at=current.last_reopened_at if current else None,
             client_type=client_type,
         )
-        saved = self._upsert(status)
+        applied, saved = self._upsert_if_current(status, current)
+        if not applied:
+            return saved
         if should_acknowledge_unhealthy_event:
             self._acknowledge_unhealthy_event(saved)
             return self._get_record(indexer_id, site_id) or saved
@@ -221,7 +234,9 @@ class IndexerSiteHealthState:
             last_reopened_at=current.last_reopened_at if current else None,
             client_type=client_type,
         )
-        saved = self._upsert(status)
+        applied, saved = self._upsert_if_current(status, current)
+        if not applied:
+            return saved
         if should_emit:
             self._emit_unhealthy_event(saved, now)
         elif should_reopen:

--- a/backend/app/services/config/indexer_client_settings.py
+++ b/backend/app/services/config/indexer_client_settings.py
@@ -71,11 +71,13 @@ class IndexerSiteHealthState:
     ) -> bool:
         try:
             event = self._build_unhealthy_event(status)
-            applied = self._repo.emit_unhealthy_event_if_current(status, event, notified_at)
-            if not applied:
-                return False
-            event_service.dispatch_persisted_event(event)
-            return True
+            dispatch_records = event_service.build_dispatch_records(event)
+            return self._repo.emit_unhealthy_event_if_current(
+                status,
+                event,
+                dispatch_records,
+                notified_at,
+            )
         except Exception as exc:
             logger.error(
                 "Failed to emit indexer site unhealthy event for %s/%s: %s",
@@ -160,29 +162,39 @@ class IndexerSiteHealthState:
         client_type: str = "jackett",
     ) -> IndexerSiteHealthStatus:
         current = self._get_record(indexer_id, site_id)
-        now = datetime.now()
-        should_acknowledge_unhealthy_event = bool(
-            current and (current.status == "unhealthy" or current.notify_pending)
-        )
-        status = IndexerSiteHealthStatus(
-            indexer_id=indexer_id,
-            indexer_name=indexer_name,
-            site_id=site_id,
-            site_name=site_name,
-            status="healthy",
-            checked_at=now,
-            last_success_at=now,
-            last_failure_at=current.last_failure_at if current else None,
-            consecutive_failures=0,
-            last_error_message=None,
-            notify_pending=should_acknowledge_unhealthy_event,
-            last_notified_at=current.last_notified_at if current else None,
-            last_reopened_at=current.last_reopened_at if current else None,
-            client_type=client_type,
-        )
-        applied, saved = self._upsert_if_current(status, current)
-        if not applied:
-            return saved
+        while True:
+            now = datetime.now()
+            if current and current.checked_at and now <= current.checked_at:
+                now = current.checked_at + timedelta(microseconds=1)
+            should_acknowledge_unhealthy_event = bool(
+                current and (current.status == "unhealthy" or current.notify_pending)
+            )
+            status = IndexerSiteHealthStatus(
+                indexer_id=indexer_id,
+                indexer_name=indexer_name,
+                site_id=site_id,
+                site_name=site_name,
+                status="healthy",
+                checked_at=now,
+                last_success_at=now,
+                last_failure_at=current.last_failure_at if current else None,
+                consecutive_failures=0,
+                last_error_message=None,
+                notify_pending=should_acknowledge_unhealthy_event,
+                last_notified_at=current.last_notified_at if current else None,
+                last_reopened_at=current.last_reopened_at if current else None,
+                client_type=client_type,
+            )
+            applied, saved = self._upsert_if_current(status, current)
+            if applied:
+                break
+            if (
+                current is None
+                or saved.status != current.status
+                or saved.checked_at != current.checked_at
+            ):
+                return saved
+            current = saved
         if should_acknowledge_unhealthy_event:
             self._acknowledge_unhealthy_event(saved)
             return self._get_record(indexer_id, site_id) or saved

--- a/backend/tests/test_indexer_site_health_alerts.py
+++ b/backend/tests/test_indexer_site_health_alerts.py
@@ -39,11 +39,7 @@ class _FakeIndexerSiteHealthRepository:
             self.before_conditional_upsert = None
             callback()
         current = self.find_one(status.indexer_id, status.site_id)
-        matches = current is None if expected is None else bool(
-            current
-            and current.status == expected.status
-            and current.checked_at == expected.checked_at
-        )
+        matches = current is None if expected is None else current == expected
         if not matches:
             return False, current or status
         return True, self.upsert(status)
@@ -413,6 +409,89 @@ def test_indexer_site_success_does_not_overwrite_failure_committed_after_read(mo
     assert recovered.consecutive_failures == 4
     assert recovered.last_error_message == "newer failure"
     assert repo.acknowledged_calls == []
+
+
+def test_indexer_site_failure_recalculates_after_concurrent_failure(monkeypatch):
+    dispatched_events = []
+    monkeypatch.setattr(
+        "app.services.config.indexer_client_settings.event_service.dispatch_persisted_event",
+        lambda event: dispatched_events.append(event),
+    )
+    repo = _FakeIndexerSiteHealthRepository()
+    state = IndexerSiteHealthState(repo=repo)
+    state.record_failure(
+        indexer_id="prowlarr",
+        indexer_name="Prowlarr",
+        site_id="audiences",
+        site_name="Audiences",
+        error_message="first failure",
+    )
+
+    def write_concurrent_failure():
+        current = repo.find_one("prowlarr", "audiences")
+        assert current is not None
+        concurrent_at = datetime.now() + timedelta(seconds=1)
+        repo.upsert(
+            current.model_copy(
+                update={
+                    "checked_at": concurrent_at,
+                    "last_failure_at": concurrent_at,
+                    "consecutive_failures": current.consecutive_failures + 1,
+                    "last_error_message": "concurrent failure",
+                }
+            )
+        )
+
+    repo.before_conditional_upsert = write_concurrent_failure
+    saved = state.record_failure(
+        indexer_id="prowlarr",
+        indexer_name="Prowlarr",
+        site_id="audiences",
+        site_name="Audiences",
+        error_message="third failure",
+    )
+
+    assert saved.consecutive_failures == 3
+    assert saved.notify_pending is True
+    assert len(dispatched_events) == 1
+
+
+def test_indexer_site_failure_recalculates_after_notification_marker_changes(monkeypatch):
+    dispatched_events = []
+    monkeypatch.setattr(
+        "app.services.config.indexer_client_settings.event_service.dispatch_persisted_event",
+        lambda event: dispatched_events.append(event),
+    )
+    repo = _FakeIndexerSiteHealthRepository()
+    state = IndexerSiteHealthState(repo=repo)
+    for _ in range(2):
+        state.record_failure(
+            indexer_id="prowlarr",
+            indexer_name="Prowlarr",
+            site_id="audiences",
+            site_name="Audiences",
+            error_message="disabled",
+        )
+
+    notified_at = datetime.now()
+
+    def write_notification_marker():
+        current = repo.find_one("prowlarr", "audiences")
+        assert current is not None
+        repo.upsert(current.model_copy(update={"last_notified_at": notified_at}))
+
+    repo.before_conditional_upsert = write_notification_marker
+    saved = state.record_failure(
+        indexer_id="prowlarr",
+        indexer_name="Prowlarr",
+        site_id="audiences",
+        site_name="Audiences",
+        error_message="third failure",
+    )
+
+    assert saved.consecutive_failures == 3
+    assert saved.last_notified_at == notified_at
+    assert dispatched_events == []
 
 
 def test_indexer_site_failure_does_not_emit_after_concurrent_recovery(monkeypatch):

--- a/backend/tests/test_indexer_site_health_alerts.py
+++ b/backend/tests/test_indexer_site_health_alerts.py
@@ -1,5 +1,10 @@
 from datetime import datetime, timedelta
 
+from sqlalchemy import select
+
+from app.db.repositories.indexer_site_health_repository import IndexerSiteHealthRepository
+from app.db.sql.models import EventAcknowledgementORM, EventORM
+from app.db.sql.session import SessionLocal
 from app.schemas.constants.event_types import EventTypes
 from app.schemas.domain.event import EventLevel
 from app.schemas.runtime.indexer_site_health import IndexerSiteHealthStatus
@@ -13,6 +18,7 @@ class _FakeIndexerSiteHealthRepository:
         self.acknowledged_calls: list[str] = []
         self.reopened_calls: list[str] = []
         self.before_acknowledge = None
+        self.before_mark_emitted = None
 
     def find_one(self, indexer_id: str, site_id: str) -> IndexerSiteHealthStatus | None:
         return self.records.get((indexer_id, site_id))
@@ -41,6 +47,22 @@ class _FakeIndexerSiteHealthRepository:
         self.records[(status.indexer_id, status.site_id)] = saved
         return True, 1
 
+    def mark_unhealthy_event_emitted(
+        self,
+        status: IndexerSiteHealthStatus,
+        notified_at: datetime,
+    ) -> bool:
+        if self.before_mark_emitted:
+            callback = self.before_mark_emitted
+            self.before_mark_emitted = None
+            callback()
+        current = self.find_one(status.indexer_id, status.site_id)
+        if not current or current.status != "unhealthy" or current.checked_at != status.checked_at:
+            return False
+        saved = current.model_copy(update={"last_notified_at": notified_at})
+        self.records[(status.indexer_id, status.site_id)] = saved
+        return True
+
     def reopen_unhealthy_events(
         self,
         status: IndexerSiteHealthStatus,
@@ -50,6 +72,8 @@ class _FakeIndexerSiteHealthRepository:
         if not current or current.status != "unhealthy" or current.checked_at != status.checked_at:
             return False, 0
         self.reopened_calls.append(correlation_id)
+        saved = current.model_copy(update={"last_reopened_at": status.checked_at})
+        self.records[(status.indexer_id, status.site_id)] = saved
         return True, 1
 
     def list_by_indexer(self, indexer_id: str) -> list[IndexerSiteHealthStatus]:
@@ -178,6 +202,40 @@ def test_indexer_site_unhealthy_event_respects_notification_cooldown(monkeypatch
     assert repo.reopened_calls == ["indexer:prowlarr:site:audiences:unhealthy"]
 
 
+def test_indexer_site_recurring_failure_reopens_event_only_once(monkeypatch):
+    monkeypatch.setattr(
+        "app.services.config.indexer_client_settings.event_service.emit",
+        lambda _event: None,
+    )
+    repo = _FakeIndexerSiteHealthRepository()
+    state = IndexerSiteHealthState(repo=repo)
+
+    for _ in range(3):
+        state.record_failure(
+            indexer_id="prowlarr",
+            indexer_name="Prowlarr",
+            site_id="audiences",
+            site_name="Audiences",
+            error_message="disabled",
+        )
+    state.record_success(
+        indexer_id="prowlarr",
+        indexer_name="Prowlarr",
+        site_id="audiences",
+        site_name="Audiences",
+    )
+    for _ in range(4):
+        state.record_failure(
+            indexer_id="prowlarr",
+            indexer_name="Prowlarr",
+            site_id="audiences",
+            site_name="Audiences",
+            error_message="disabled again",
+        )
+
+    assert repo.reopened_calls == ["indexer:prowlarr:site:audiences:unhealthy"]
+
+
 def test_indexer_site_success_acknowledges_unhealthy_warning_event(monkeypatch):
     emitted_events = []
     monkeypatch.setattr(
@@ -284,6 +342,107 @@ def test_indexer_site_success_does_not_acknowledge_after_concurrent_failure(monk
     assert recovered.status == "unhealthy"
     assert recovered.notify_pending is True
     assert repo.acknowledged_calls == []
+
+
+def test_indexer_site_failure_does_not_overwrite_concurrent_recovery_after_emit(monkeypatch):
+    monkeypatch.setattr(
+        "app.services.config.indexer_client_settings.event_service.emit",
+        lambda _event: None,
+    )
+    repo = _FakeIndexerSiteHealthRepository()
+    state = IndexerSiteHealthState(repo=repo)
+
+    def write_concurrent_recovery():
+        current = repo.find_one("prowlarr", "audiences")
+        assert current is not None
+        repo.upsert(
+            current.model_copy(
+                update={
+                    "status": "healthy",
+                    "checked_at": datetime.now() + timedelta(seconds=1),
+                    "consecutive_failures": 0,
+                    "notify_pending": False,
+                }
+            )
+        )
+
+    repo.before_mark_emitted = write_concurrent_recovery
+    for _ in range(3):
+        status = state.record_failure(
+            indexer_id="prowlarr",
+            indexer_name="Prowlarr",
+            site_id="audiences",
+            site_name="Audiences",
+            error_message="disabled",
+        )
+
+    assert status.status == "healthy"
+    assert status.notify_pending is False
+    assert status.last_notified_at is None
+
+
+def test_reopen_unhealthy_events_reopens_only_latest_matching_event():
+    repo = IndexerSiteHealthRepository()
+    checked_at = datetime.now()
+    status = IndexerSiteHealthStatus(
+        indexer_id="prowlarr",
+        indexer_name="Prowlarr",
+        site_id="audiences",
+        site_name="Audiences",
+        status="unhealthy",
+        checked_at=checked_at,
+        consecutive_failures=3,
+        notify_pending=True,
+    )
+    repo.upsert(status)
+    correlation_id = "indexer:prowlarr:site:audiences:unhealthy"
+    with SessionLocal.begin() as session:
+        session.add_all(
+            [
+                EventORM(
+                    id="indexer-old-warning",
+                    ts="2026-08-01T00:00:00",
+                    type=EventTypes.INDEXER_SITE_UNHEALTHY.value,
+                    level=EventLevel.warning.value,
+                    message_params_json={},
+                    search_text="",
+                    entities_json=[],
+                    meta_json={},
+                    correlation_id=correlation_id,
+                ),
+                EventORM(
+                    id="indexer-current-warning",
+                    ts="2026-08-02T00:00:00",
+                    type=EventTypes.INDEXER_SITE_UNHEALTHY.value,
+                    level=EventLevel.warning.value,
+                    message_params_json={},
+                    search_text="",
+                    entities_json=[],
+                    meta_json={},
+                    correlation_id=correlation_id,
+                ),
+                EventAcknowledgementORM(
+                    event_id="indexer-old-warning",
+                    acknowledged_at="2026-08-03T00:00:00",
+                ),
+                EventAcknowledgementORM(
+                    event_id="indexer-current-warning",
+                    acknowledged_at="2026-08-03T00:00:00",
+                ),
+            ]
+        )
+
+    applied, reopened_count = repo.reopen_unhealthy_events(status, correlation_id)
+
+    with SessionLocal() as session:
+        acknowledged_ids = set(session.execute(select(EventAcknowledgementORM.event_id)).scalars().all())
+
+    assert applied is True
+    assert reopened_count == 1
+    assert acknowledged_ids == {"indexer-old-warning"}
+    saved = repo.find_one("prowlarr", "audiences")
+    assert saved is not None
+    assert saved.last_reopened_at == checked_at
 
 
 def test_indexer_site_unhealthy_event_repeats_after_notification_cooldown(monkeypatch):

--- a/backend/tests/test_indexer_site_health_alerts.py
+++ b/backend/tests/test_indexer_site_health_alerts.py
@@ -19,6 +19,7 @@ class _FakeIndexerSiteHealthRepository:
         self.reopened_calls: list[str] = []
         self.before_acknowledge = None
         self.before_emit = None
+        self.before_conditional_upsert = None
         self.emit_failures_remaining = 0
 
     def find_one(self, indexer_id: str, site_id: str) -> IndexerSiteHealthStatus | None:
@@ -27,6 +28,25 @@ class _FakeIndexerSiteHealthRepository:
     def upsert(self, status: IndexerSiteHealthStatus) -> IndexerSiteHealthStatus:
         self.records[(status.indexer_id, status.site_id)] = status
         return status
+
+    def upsert_if_current(
+        self,
+        status: IndexerSiteHealthStatus,
+        expected: IndexerSiteHealthStatus | None,
+    ) -> tuple[bool, IndexerSiteHealthStatus]:
+        if self.before_conditional_upsert:
+            callback = self.before_conditional_upsert
+            self.before_conditional_upsert = None
+            callback()
+        current = self.find_one(status.indexer_id, status.site_id)
+        matches = current is None if expected is None else bool(
+            current
+            and current.status == expected.status
+            and current.checked_at == expected.checked_at
+        )
+        if not matches:
+            return False, current or status
+        return True, self.upsert(status)
 
     def acknowledge_recovered_unhealthy_events(
         self,
@@ -72,6 +92,7 @@ class _FakeIndexerSiteHealthRepository:
         self,
         status: IndexerSiteHealthStatus,
         correlation_id: str,
+        _fallback_event,
     ) -> tuple[bool, int]:
         current = self.find_one(status.indexer_id, status.site_id)
         if not current or current.status != "unhealthy" or current.checked_at != status.checked_at:
@@ -349,6 +370,51 @@ def test_indexer_site_success_does_not_acknowledge_after_concurrent_failure(monk
     assert repo.acknowledged_calls == []
 
 
+def test_indexer_site_success_does_not_overwrite_failure_committed_after_read(monkeypatch):
+    monkeypatch.setattr(
+        "app.services.config.indexer_client_settings.event_service.dispatch_persisted_event",
+        lambda _event: None,
+    )
+    repo = _FakeIndexerSiteHealthRepository()
+    state = IndexerSiteHealthState(repo=repo)
+
+    for _ in range(3):
+        state.record_failure(
+            indexer_id="prowlarr",
+            indexer_name="Prowlarr",
+            site_id="audiences",
+            site_name="Audiences",
+            error_message="disabled",
+        )
+
+    def write_newer_failure():
+        current = repo.find_one("prowlarr", "audiences")
+        assert current is not None
+        repo.upsert(
+            current.model_copy(
+                update={
+                    "checked_at": datetime.now() + timedelta(seconds=1),
+                    "consecutive_failures": current.consecutive_failures + 1,
+                    "last_error_message": "newer failure",
+                    "notify_pending": True,
+                }
+            )
+        )
+
+    repo.before_conditional_upsert = write_newer_failure
+    recovered = state.record_success(
+        indexer_id="prowlarr",
+        indexer_name="Prowlarr",
+        site_id="audiences",
+        site_name="Audiences",
+    )
+
+    assert recovered.status == "unhealthy"
+    assert recovered.consecutive_failures == 4
+    assert recovered.last_error_message == "newer failure"
+    assert repo.acknowledged_calls == []
+
+
 def test_indexer_site_failure_does_not_emit_after_concurrent_recovery(monkeypatch):
     dispatched_events = []
     monkeypatch.setattr(
@@ -439,7 +505,17 @@ def test_reopen_unhealthy_events_reopens_only_latest_matching_event():
             ]
         )
 
-    applied, reopened_count = repo.reopen_unhealthy_events(status, correlation_id)
+    fallback_event = Event(
+        id="indexer-fallback-warning",
+        type=EventTypes.INDEXER_SITE_UNHEALTHY,
+        level=EventLevel.warning,
+        correlation_id=correlation_id,
+    )
+    applied, reopened_count = repo.reopen_unhealthy_events(
+        status,
+        correlation_id,
+        fallback_event,
+    )
 
     with SessionLocal() as session:
         acknowledged_ids = set(session.execute(select(EventAcknowledgementORM.event_id)).scalars().all())
@@ -461,9 +537,57 @@ def test_reopen_unhealthy_events_reopens_only_latest_matching_event():
         )
         session.execute(
             delete(EventORM).where(
-                EventORM.id.in_(["indexer-old-warning", "indexer-current-warning"])
+                EventORM.id.in_([
+                    "indexer-old-warning",
+                    "indexer-current-warning",
+                    "indexer-fallback-warning",
+                ])
             )
         )
+
+
+def test_reopen_unhealthy_events_creates_warning_when_history_was_pruned():
+    repo = IndexerSiteHealthRepository()
+    checked_at = datetime.now()
+    status = IndexerSiteHealthStatus(
+        indexer_id="pruned-indexer",
+        site_id="pruned-site",
+        status="unhealthy",
+        checked_at=checked_at,
+        consecutive_failures=3,
+        notify_pending=True,
+    )
+    repo.upsert(status)
+    correlation_id = "indexer:pruned-indexer:site:pruned-site:unhealthy"
+    fallback_event = Event(
+        id="pruned-indexer-warning",
+        type=EventTypes.INDEXER_SITE_UNHEALTHY,
+        level=EventLevel.warning,
+        correlation_id=correlation_id,
+    )
+
+    applied, reopened_count = repo.reopen_unhealthy_events(
+        status,
+        correlation_id,
+        fallback_event,
+    )
+    saved = repo.find_one(status.indexer_id, status.site_id)
+
+    with SessionLocal.begin() as session:
+        persisted_event = session.get(EventORM, fallback_event.id)
+        session.execute(delete(EventORM).where(EventORM.id == fallback_event.id))
+        session.execute(
+            delete(IndexerSiteHealthORM).where(
+                IndexerSiteHealthORM.indexer_id == status.indexer_id,
+                IndexerSiteHealthORM.site_id == status.site_id,
+            )
+        )
+
+    assert applied is True
+    assert reopened_count == 1
+    assert persisted_event is not None
+    assert saved is not None
+    assert saved.last_reopened_at == checked_at
 
 
 def test_emit_unhealthy_event_rejects_stale_failure_without_inserting_event():

--- a/backend/tests/test_indexer_site_health_alerts.py
+++ b/backend/tests/test_indexer_site_health_alerts.py
@@ -1,13 +1,21 @@
 from datetime import datetime, timedelta
 
+import pytest
 from sqlalchemy import delete, select
+from sqlalchemy.exc import IntegrityError
 
 from app.db.repositories.indexer_site_health_repository import IndexerSiteHealthRepository
-from app.db.sql.models import EventAcknowledgementORM, EventORM, IndexerSiteHealthORM
+from app.db.sql.models import (
+    EventAcknowledgementORM,
+    EventDispatchORM,
+    EventORM,
+    IndexerSiteHealthORM,
+)
 from app.db.sql.session import SessionLocal
 from app.schemas.constants.event_types import EventTypes
 from app.schemas.domain.event import Event, EventLevel
 from app.schemas.runtime.indexer_site_health import IndexerSiteHealthStatus
+from app.schemas.persistence.event_dispatch import EventDispatchRecord
 from app.services.config.indexer_client_settings import IndexerSiteHealthState
 
 
@@ -21,6 +29,7 @@ class _FakeIndexerSiteHealthRepository:
         self.before_emit = None
         self.before_conditional_upsert = None
         self.emit_failures_remaining = 0
+        self.emitted_events = []
 
     def find_one(self, indexer_id: str, site_id: str) -> IndexerSiteHealthStatus | None:
         return self.records.get((indexer_id, site_id))
@@ -67,7 +76,8 @@ class _FakeIndexerSiteHealthRepository:
     def emit_unhealthy_event_if_current(
         self,
         status: IndexerSiteHealthStatus,
-        _event,
+        event,
+        _dispatch_records,
         notified_at: datetime,
     ) -> bool:
         if self.before_emit:
@@ -82,6 +92,7 @@ class _FakeIndexerSiteHealthRepository:
             return False
         saved = current.model_copy(update={"last_notified_at": notified_at})
         self.records[(status.indexer_id, status.site_id)] = saved
+        self.emitted_events.append(event)
         return True
 
     def reopen_unhealthy_events(
@@ -131,7 +142,8 @@ def test_indexer_site_failure_emits_unhealthy_event_once_at_threshold(monkeypatc
         "app.services.config.indexer_client_settings.event_service.dispatch_persisted_event",
         lambda event: emitted_events.append(event),
     )
-    state = IndexerSiteHealthState(repo=_FakeIndexerSiteHealthRepository())
+    repo = _FakeIndexerSiteHealthRepository()
+    state = IndexerSiteHealthState(repo=repo)
 
     for failure_count in range(1, 5):
         state.record_failure(
@@ -142,8 +154,8 @@ def test_indexer_site_failure_emits_unhealthy_event_once_at_threshold(monkeypatc
             error_message=f"failure {failure_count}",
         )
 
-    assert len(emitted_events) == 1
-    event = emitted_events[0]
+    assert len(repo.emitted_events) == 1
+    event = repo.emitted_events[0]
     assert event.type == EventTypes.INDEXER_SITE_UNHEALTHY
     assert event.level == EventLevel.warning
     assert event.message_params["indexer_name"] == "Jackett"
@@ -220,7 +232,7 @@ def test_indexer_site_unhealthy_event_respects_notification_cooldown(monkeypatch
             error_message="disabled again",
         )
 
-    assert len(emitted_events) == 1
+    assert len(repo.emitted_events) == 1
     assert repo.reopened_calls == ["indexer:prowlarr:site:audiences:unhealthy"]
 
 
@@ -283,7 +295,7 @@ def test_indexer_site_success_acknowledges_unhealthy_warning_event(monkeypatch):
         site_name="Audiences",
     )
 
-    assert len(emitted_events) == 1
+    assert len(repo.emitted_events) == 1
     assert repo.acknowledged_calls == ["indexer:prowlarr:site:audiences:unhealthy"]
 
 
@@ -411,6 +423,40 @@ def test_indexer_site_success_does_not_overwrite_failure_committed_after_read(mo
     assert repo.acknowledged_calls == []
 
 
+def test_indexer_site_success_retries_after_notification_metadata_changes(monkeypatch):
+    repo = _FakeIndexerSiteHealthRepository()
+    state = IndexerSiteHealthState(repo=repo)
+    for _ in range(3):
+        state.record_failure(
+            indexer_id="prowlarr",
+            indexer_name="Prowlarr",
+            site_id="audiences",
+            site_name="Audiences",
+            error_message="disabled",
+        )
+    current = repo.find_one("prowlarr", "audiences")
+    assert current is not None
+    notified_at = (current.last_notified_at or datetime.now()) + timedelta(seconds=1)
+
+    def update_notification_metadata():
+        latest = repo.find_one("prowlarr", "audiences")
+        assert latest is not None
+        repo.upsert(latest.model_copy(update={"last_notified_at": notified_at}))
+
+    repo.before_conditional_upsert = update_notification_metadata
+    recovered = state.record_success(
+        indexer_id="prowlarr",
+        indexer_name="Prowlarr",
+        site_id="audiences",
+        site_name="Audiences",
+    )
+
+    assert recovered.status == "healthy"
+    assert recovered.notify_pending is False
+    assert recovered.last_notified_at == notified_at
+    assert repo.acknowledged_calls == ["indexer:prowlarr:site:audiences:unhealthy"]
+
+
 def test_indexer_site_failure_recalculates_after_concurrent_failure(monkeypatch):
     dispatched_events = []
     monkeypatch.setattr(
@@ -453,7 +499,7 @@ def test_indexer_site_failure_recalculates_after_concurrent_failure(monkeypatch)
 
     assert saved.consecutive_failures == 3
     assert saved.notify_pending is True
-    assert len(dispatched_events) == 1
+    assert len(repo.emitted_events) == 1
 
 
 def test_indexer_site_failure_recalculates_after_notification_marker_changes(monkeypatch):
@@ -491,7 +537,7 @@ def test_indexer_site_failure_recalculates_after_notification_marker_changes(mon
 
     assert saved.consecutive_failures == 3
     assert saved.last_notified_at == notified_at
-    assert dispatched_events == []
+    assert repo.emitted_events == []
 
 
 def test_indexer_site_failure_does_not_emit_after_concurrent_recovery(monkeypatch):
@@ -530,7 +576,7 @@ def test_indexer_site_failure_does_not_emit_after_concurrent_recovery(monkeypatc
     assert status.status == "healthy"
     assert status.notify_pending is False
     assert status.last_notified_at is None
-    assert dispatched_events == []
+    assert repo.emitted_events == []
 
 
 def test_reopen_unhealthy_events_reopens_only_latest_matching_event():
@@ -696,7 +742,7 @@ def test_emit_unhealthy_event_rejects_stale_failure_without_inserting_event():
         level=EventLevel.warning,
     )
 
-    applied = repo.emit_unhealthy_event_if_current(stale_failure, event, checked_at)
+    applied = repo.emit_unhealthy_event_if_current(stale_failure, event, [], checked_at)
 
     with SessionLocal.begin() as session:
         persisted_event = session.get(EventORM, event.id)
@@ -709,6 +755,116 @@ def test_emit_unhealthy_event_rejects_stale_failure_without_inserting_event():
 
     assert applied is False
     assert persisted_event is None
+
+
+def test_emit_unhealthy_event_queues_dispatch_and_cooldown_atomically():
+    repo = IndexerSiteHealthRepository()
+    checked_at = datetime.now()
+    status = IndexerSiteHealthStatus(
+        indexer_id="dispatch-indexer",
+        site_id="dispatch-site",
+        status="unhealthy",
+        checked_at=checked_at,
+        consecutive_failures=3,
+        notify_pending=True,
+    )
+    repo.upsert(status)
+    event = Event(
+        id="dispatch-indexer-warning",
+        type=EventTypes.INDEXER_SITE_UNHEALTHY,
+        level=EventLevel.warning,
+    )
+    dispatch = EventDispatchRecord(
+        id="dispatch-indexer-warning-telegram",
+        event_id=event.id,
+        consumer_name="notifications",
+    )
+
+    applied = repo.emit_unhealthy_event_if_current(
+        status,
+        event,
+        [dispatch],
+        checked_at,
+    )
+    saved = repo.find_one(status.indexer_id, status.site_id)
+
+    with SessionLocal.begin() as session:
+        persisted_event = session.get(EventORM, event.id)
+        persisted_dispatch = session.get(EventDispatchORM, dispatch.id)
+        session.execute(delete(EventDispatchORM).where(EventDispatchORM.id == dispatch.id))
+        session.execute(delete(EventORM).where(EventORM.id == event.id))
+        session.execute(
+            delete(IndexerSiteHealthORM).where(
+                IndexerSiteHealthORM.indexer_id == status.indexer_id,
+                IndexerSiteHealthORM.site_id == status.site_id,
+            )
+        )
+
+    assert applied is True
+    assert persisted_event is not None
+    assert persisted_dispatch is not None
+    assert saved is not None
+    assert saved.last_notified_at == checked_at
+
+
+def test_emit_unhealthy_event_rolls_back_when_dispatch_queue_insert_fails():
+    repo = IndexerSiteHealthRepository()
+    checked_at = datetime.now()
+    status = IndexerSiteHealthStatus(
+        indexer_id="dispatch-rollback-indexer",
+        site_id="dispatch-rollback-site",
+        status="unhealthy",
+        checked_at=checked_at,
+        consecutive_failures=3,
+        notify_pending=True,
+    )
+    repo.upsert(status)
+    event = Event(
+        id="dispatch-rollback-warning",
+        type=EventTypes.INDEXER_SITE_UNHEALTHY,
+        level=EventLevel.warning,
+    )
+    dispatch = EventDispatchRecord(
+        id="dispatch-conflict",
+        event_id=event.id,
+        consumer_name="notifications",
+    )
+    with SessionLocal.begin() as session:
+        session.add(
+            EventDispatchORM(
+                id=dispatch.id,
+                event_id="existing-event",
+                consumer_name="notifications",
+                status="queued",
+                attempts=0,
+                max_attempts=3,
+                available_at=checked_at.isoformat(),
+                created_at=checked_at.isoformat(),
+            )
+        )
+
+    with pytest.raises(IntegrityError):
+        repo.emit_unhealthy_event_if_current(
+            status,
+            event,
+            [dispatch],
+            checked_at,
+        )
+
+    saved = repo.find_one(status.indexer_id, status.site_id)
+    with SessionLocal.begin() as session:
+        persisted_event = session.get(EventORM, event.id)
+        session.execute(delete(EventDispatchORM).where(EventDispatchORM.id == dispatch.id))
+        session.execute(
+            delete(IndexerSiteHealthORM).where(
+                IndexerSiteHealthORM.indexer_id == status.indexer_id,
+                IndexerSiteHealthORM.site_id == status.site_id,
+            )
+        )
+
+    assert persisted_event is None
+    assert saved is not None
+    assert saved.last_notified_at is None
 
 
 def test_indexer_site_unhealthy_event_repeats_after_notification_cooldown(monkeypatch):
@@ -741,7 +897,7 @@ def test_indexer_site_unhealthy_event_repeats_after_notification_cooldown(monkey
         error_message="still disabled",
     )
 
-    assert len(emitted_events) == 1
+    assert len(repo.emitted_events) == 1
 
 
 def test_indexer_site_unhealthy_event_failure_does_not_start_cooldown(monkeypatch):
@@ -773,5 +929,5 @@ def test_indexer_site_unhealthy_event_failure_does_not_start_cooldown(monkeypatc
         error_message="still disabled",
     )
 
-    assert len(attempts) == 1
+    assert len(repo.emitted_events) == 1
     assert status.last_notified_at is not None

--- a/backend/tests/test_indexer_site_health_alerts.py
+++ b/backend/tests/test_indexer_site_health_alerts.py
@@ -1,12 +1,12 @@
 from datetime import datetime, timedelta
 
-from sqlalchemy import select
+from sqlalchemy import delete, select
 
 from app.db.repositories.indexer_site_health_repository import IndexerSiteHealthRepository
-from app.db.sql.models import EventAcknowledgementORM, EventORM
+from app.db.sql.models import EventAcknowledgementORM, EventORM, IndexerSiteHealthORM
 from app.db.sql.session import SessionLocal
 from app.schemas.constants.event_types import EventTypes
-from app.schemas.domain.event import EventLevel
+from app.schemas.domain.event import Event, EventLevel
 from app.schemas.runtime.indexer_site_health import IndexerSiteHealthStatus
 from app.services.config.indexer_client_settings import IndexerSiteHealthState
 
@@ -18,7 +18,8 @@ class _FakeIndexerSiteHealthRepository:
         self.acknowledged_calls: list[str] = []
         self.reopened_calls: list[str] = []
         self.before_acknowledge = None
-        self.before_mark_emitted = None
+        self.before_emit = None
+        self.emit_failures_remaining = 0
 
     def find_one(self, indexer_id: str, site_id: str) -> IndexerSiteHealthStatus | None:
         return self.records.get((indexer_id, site_id))
@@ -47,15 +48,19 @@ class _FakeIndexerSiteHealthRepository:
         self.records[(status.indexer_id, status.site_id)] = saved
         return True, 1
 
-    def mark_unhealthy_event_emitted(
+    def emit_unhealthy_event_if_current(
         self,
         status: IndexerSiteHealthStatus,
+        _event,
         notified_at: datetime,
     ) -> bool:
-        if self.before_mark_emitted:
-            callback = self.before_mark_emitted
-            self.before_mark_emitted = None
+        if self.before_emit:
+            callback = self.before_emit
+            self.before_emit = None
             callback()
+        if self.emit_failures_remaining:
+            self.emit_failures_remaining -= 1
+            raise RuntimeError("event store unavailable")
         current = self.find_one(status.indexer_id, status.site_id)
         if not current or current.status != "unhealthy" or current.checked_at != status.checked_at:
             return False
@@ -106,7 +111,7 @@ def test_indexer_site_failure_marks_notify_pending_after_threshold():
 def test_indexer_site_failure_emits_unhealthy_event_once_at_threshold(monkeypatch):
     emitted_events = []
     monkeypatch.setattr(
-        "app.services.config.indexer_client_settings.event_service.emit",
+        "app.services.config.indexer_client_settings.event_service.dispatch_persisted_event",
         lambda event: emitted_events.append(event),
     )
     state = IndexerSiteHealthState(repo=_FakeIndexerSiteHealthRepository())
@@ -169,7 +174,7 @@ def test_indexer_site_success_clears_notify_pending_and_allows_future_threshold(
 def test_indexer_site_unhealthy_event_respects_notification_cooldown(monkeypatch):
     emitted_events = []
     monkeypatch.setattr(
-        "app.services.config.indexer_client_settings.event_service.emit",
+        "app.services.config.indexer_client_settings.event_service.dispatch_persisted_event",
         lambda event: emitted_events.append(event),
     )
     repo = _FakeIndexerSiteHealthRepository()
@@ -204,7 +209,7 @@ def test_indexer_site_unhealthy_event_respects_notification_cooldown(monkeypatch
 
 def test_indexer_site_recurring_failure_reopens_event_only_once(monkeypatch):
     monkeypatch.setattr(
-        "app.services.config.indexer_client_settings.event_service.emit",
+        "app.services.config.indexer_client_settings.event_service.dispatch_persisted_event",
         lambda _event: None,
     )
     repo = _FakeIndexerSiteHealthRepository()
@@ -239,7 +244,7 @@ def test_indexer_site_recurring_failure_reopens_event_only_once(monkeypatch):
 def test_indexer_site_success_acknowledges_unhealthy_warning_event(monkeypatch):
     emitted_events = []
     monkeypatch.setattr(
-        "app.services.config.indexer_client_settings.event_service.emit",
+        "app.services.config.indexer_client_settings.event_service.dispatch_persisted_event",
         lambda event: emitted_events.append(event),
     )
     repo = _FakeIndexerSiteHealthRepository()
@@ -267,7 +272,7 @@ def test_indexer_site_success_acknowledges_unhealthy_warning_event(monkeypatch):
 
 def test_indexer_site_success_retries_failed_recovery_acknowledgement(monkeypatch):
     monkeypatch.setattr(
-        "app.services.config.indexer_client_settings.event_service.emit",
+        "app.services.config.indexer_client_settings.event_service.dispatch_persisted_event",
         lambda _event: None,
     )
     repo = _FakeIndexerSiteHealthRepository()
@@ -303,7 +308,7 @@ def test_indexer_site_success_retries_failed_recovery_acknowledgement(monkeypatc
 
 def test_indexer_site_success_does_not_acknowledge_after_concurrent_failure(monkeypatch):
     monkeypatch.setattr(
-        "app.services.config.indexer_client_settings.event_service.emit",
+        "app.services.config.indexer_client_settings.event_service.dispatch_persisted_event",
         lambda _event: None,
     )
     repo = _FakeIndexerSiteHealthRepository()
@@ -344,10 +349,11 @@ def test_indexer_site_success_does_not_acknowledge_after_concurrent_failure(monk
     assert repo.acknowledged_calls == []
 
 
-def test_indexer_site_failure_does_not_overwrite_concurrent_recovery_after_emit(monkeypatch):
+def test_indexer_site_failure_does_not_emit_after_concurrent_recovery(monkeypatch):
+    dispatched_events = []
     monkeypatch.setattr(
-        "app.services.config.indexer_client_settings.event_service.emit",
-        lambda _event: None,
+        "app.services.config.indexer_client_settings.event_service.dispatch_persisted_event",
+        lambda event: dispatched_events.append(event),
     )
     repo = _FakeIndexerSiteHealthRepository()
     state = IndexerSiteHealthState(repo=repo)
@@ -366,7 +372,7 @@ def test_indexer_site_failure_does_not_overwrite_concurrent_recovery_after_emit(
             )
         )
 
-    repo.before_mark_emitted = write_concurrent_recovery
+    repo.before_emit = write_concurrent_recovery
     for _ in range(3):
         status = state.record_failure(
             indexer_id="prowlarr",
@@ -379,6 +385,7 @@ def test_indexer_site_failure_does_not_overwrite_concurrent_recovery_after_emit(
     assert status.status == "healthy"
     assert status.notify_pending is False
     assert status.last_notified_at is None
+    assert dispatched_events == []
 
 
 def test_reopen_unhealthy_events_reopens_only_latest_matching_event():
@@ -443,12 +450,68 @@ def test_reopen_unhealthy_events_reopens_only_latest_matching_event():
     saved = repo.find_one("prowlarr", "audiences")
     assert saved is not None
     assert saved.last_reopened_at == checked_at
+    with SessionLocal.begin() as session:
+        session.execute(
+            delete(EventAcknowledgementORM).where(
+                EventAcknowledgementORM.event_id.in_([
+                    "indexer-old-warning",
+                    "indexer-current-warning",
+                ])
+            )
+        )
+        session.execute(
+            delete(EventORM).where(
+                EventORM.id.in_(["indexer-old-warning", "indexer-current-warning"])
+            )
+        )
+
+
+def test_emit_unhealthy_event_rejects_stale_failure_without_inserting_event():
+    repo = IndexerSiteHealthRepository()
+    checked_at = datetime.now()
+    stale_failure = IndexerSiteHealthStatus(
+        indexer_id="atomic-indexer",
+        site_id="atomic-site",
+        status="unhealthy",
+        checked_at=checked_at,
+        consecutive_failures=3,
+        notify_pending=True,
+    )
+    repo.upsert(
+        stale_failure.model_copy(
+            update={
+                "status": "healthy",
+                "checked_at": checked_at + timedelta(seconds=1),
+                "consecutive_failures": 0,
+                "notify_pending": False,
+            }
+        )
+    )
+    event = Event(
+        id="stale-indexer-warning",
+        type=EventTypes.INDEXER_SITE_UNHEALTHY,
+        level=EventLevel.warning,
+    )
+
+    applied = repo.emit_unhealthy_event_if_current(stale_failure, event, checked_at)
+
+    with SessionLocal.begin() as session:
+        persisted_event = session.get(EventORM, event.id)
+        session.execute(
+            delete(IndexerSiteHealthORM).where(
+                IndexerSiteHealthORM.indexer_id == "atomic-indexer",
+                IndexerSiteHealthORM.site_id == "atomic-site",
+            )
+        )
+
+    assert applied is False
+    assert persisted_event is None
 
 
 def test_indexer_site_unhealthy_event_repeats_after_notification_cooldown(monkeypatch):
     emitted_events = []
     monkeypatch.setattr(
-        "app.services.config.indexer_client_settings.event_service.emit",
+        "app.services.config.indexer_client_settings.event_service.dispatch_persisted_event",
         lambda event: emitted_events.append(event),
     )
     repo = _FakeIndexerSiteHealthRepository()
@@ -480,17 +543,13 @@ def test_indexer_site_unhealthy_event_repeats_after_notification_cooldown(monkey
 
 def test_indexer_site_unhealthy_event_failure_does_not_start_cooldown(monkeypatch):
     attempts = []
-
-    def fake_emit(event):
-        attempts.append(event)
-        if len(attempts) == 1:
-            raise RuntimeError("event store unavailable")
-
     monkeypatch.setattr(
-        "app.services.config.indexer_client_settings.event_service.emit",
-        fake_emit,
+        "app.services.config.indexer_client_settings.event_service.dispatch_persisted_event",
+        lambda event: attempts.append(event),
     )
-    state = IndexerSiteHealthState(repo=_FakeIndexerSiteHealthRepository())
+    repo = _FakeIndexerSiteHealthRepository()
+    repo.emit_failures_remaining = 1
+    state = IndexerSiteHealthState(repo=repo)
 
     for _ in range(3):
         status = state.record_failure(
@@ -511,5 +570,5 @@ def test_indexer_site_unhealthy_event_failure_does_not_start_cooldown(monkeypatc
         error_message="still disabled",
     )
 
-    assert len(attempts) == 2
+    assert len(attempts) == 1
     assert status.last_notified_at is not None

--- a/backend/tests/test_indexer_site_health_alerts.py
+++ b/backend/tests/test_indexer_site_health_alerts.py
@@ -9,6 +9,10 @@ from app.services.config.indexer_client_settings import IndexerSiteHealthState
 class _FakeIndexerSiteHealthRepository:
     def __init__(self) -> None:
         self.records: dict[tuple[str, str], IndexerSiteHealthStatus] = {}
+        self.acknowledge_failures_remaining = 0
+        self.acknowledged_calls: list[str] = []
+        self.reopened_calls: list[str] = []
+        self.before_acknowledge = None
 
     def find_one(self, indexer_id: str, site_id: str) -> IndexerSiteHealthStatus | None:
         return self.records.get((indexer_id, site_id))
@@ -16,6 +20,37 @@ class _FakeIndexerSiteHealthRepository:
     def upsert(self, status: IndexerSiteHealthStatus) -> IndexerSiteHealthStatus:
         self.records[(status.indexer_id, status.site_id)] = status
         return status
+
+    def acknowledge_recovered_unhealthy_events(
+        self,
+        status: IndexerSiteHealthStatus,
+        correlation_id: str,
+    ) -> tuple[bool, int]:
+        if self.before_acknowledge:
+            callback = self.before_acknowledge
+            self.before_acknowledge = None
+            callback()
+        if self.acknowledge_failures_remaining:
+            self.acknowledge_failures_remaining -= 1
+            raise RuntimeError("event store unavailable")
+        current = self.find_one(status.indexer_id, status.site_id)
+        if not current or current.status != "healthy" or current.checked_at != status.checked_at:
+            return False, 0
+        self.acknowledged_calls.append(correlation_id)
+        saved = current.model_copy(update={"notify_pending": False})
+        self.records[(status.indexer_id, status.site_id)] = saved
+        return True, 1
+
+    def reopen_unhealthy_events(
+        self,
+        status: IndexerSiteHealthStatus,
+        correlation_id: str,
+    ) -> tuple[bool, int]:
+        current = self.find_one(status.indexer_id, status.site_id)
+        if not current or current.status != "unhealthy" or current.checked_at != status.checked_at:
+            return False, 0
+        self.reopened_calls.append(correlation_id)
+        return True, 1
 
     def list_by_indexer(self, indexer_id: str) -> list[IndexerSiteHealthStatus]:
         return [
@@ -70,11 +105,7 @@ def test_indexer_site_failure_emits_unhealthy_event_once_at_threshold(monkeypatc
     assert event.message_params["consecutive_failures"] == "3"
 
 
-def test_indexer_site_success_clears_notify_pending_and_allows_future_threshold(monkeypatch):
-    monkeypatch.setattr(
-        "app.services.config.indexer_client_settings.event_service.acknowledge_matching_events",
-        lambda **_kwargs: 0,
-    )
+def test_indexer_site_success_clears_notify_pending_and_allows_future_threshold():
     state = IndexerSiteHealthState(repo=_FakeIndexerSiteHealthRepository())
 
     for _ in range(3):
@@ -117,11 +148,8 @@ def test_indexer_site_unhealthy_event_respects_notification_cooldown(monkeypatch
         "app.services.config.indexer_client_settings.event_service.emit",
         lambda event: emitted_events.append(event),
     )
-    monkeypatch.setattr(
-        "app.services.config.indexer_client_settings.event_service.acknowledge_matching_events",
-        lambda **_kwargs: 0,
-    )
-    state = IndexerSiteHealthState(repo=_FakeIndexerSiteHealthRepository())
+    repo = _FakeIndexerSiteHealthRepository()
+    state = IndexerSiteHealthState(repo=repo)
 
     for _ in range(3):
         state.record_failure(
@@ -147,20 +175,17 @@ def test_indexer_site_unhealthy_event_respects_notification_cooldown(monkeypatch
         )
 
     assert len(emitted_events) == 1
+    assert repo.reopened_calls == ["indexer:prowlarr:site:audiences:unhealthy"]
 
 
 def test_indexer_site_success_acknowledges_unhealthy_warning_event(monkeypatch):
     emitted_events = []
-    acknowledged_calls = []
     monkeypatch.setattr(
         "app.services.config.indexer_client_settings.event_service.emit",
         lambda event: emitted_events.append(event),
     )
-    monkeypatch.setattr(
-        "app.services.config.indexer_client_settings.event_service.acknowledge_matching_events",
-        lambda **kwargs: acknowledged_calls.append(kwargs) or 1,
-    )
-    state = IndexerSiteHealthState(repo=_FakeIndexerSiteHealthRepository())
+    repo = _FakeIndexerSiteHealthRepository()
+    state = IndexerSiteHealthState(repo=repo)
 
     for _ in range(3):
         state.record_failure(
@@ -179,13 +204,86 @@ def test_indexer_site_success_acknowledges_unhealthy_warning_event(monkeypatch):
     )
 
     assert len(emitted_events) == 1
-    assert acknowledged_calls == [
-        {
-            "correlation_id": "indexer:prowlarr:site:audiences:unhealthy",
-            "types": [EventTypes.INDEXER_SITE_UNHEALTHY],
-            "levels": [EventLevel.warning],
-        }
-    ]
+    assert repo.acknowledged_calls == ["indexer:prowlarr:site:audiences:unhealthy"]
+
+
+def test_indexer_site_success_retries_failed_recovery_acknowledgement(monkeypatch):
+    monkeypatch.setattr(
+        "app.services.config.indexer_client_settings.event_service.emit",
+        lambda _event: None,
+    )
+    repo = _FakeIndexerSiteHealthRepository()
+    repo.acknowledge_failures_remaining = 1
+    state = IndexerSiteHealthState(repo=repo)
+
+    for _ in range(3):
+        state.record_failure(
+            indexer_id="prowlarr",
+            indexer_name="Prowlarr",
+            site_id="audiences",
+            site_name="Audiences",
+            error_message="disabled",
+        )
+
+    first_recovery = state.record_success(
+        indexer_id="prowlarr",
+        indexer_name="Prowlarr",
+        site_id="audiences",
+        site_name="Audiences",
+    )
+    second_recovery = state.record_success(
+        indexer_id="prowlarr",
+        indexer_name="Prowlarr",
+        site_id="audiences",
+        site_name="Audiences",
+    )
+
+    assert first_recovery.notify_pending is True
+    assert second_recovery.notify_pending is False
+    assert repo.acknowledged_calls == ["indexer:prowlarr:site:audiences:unhealthy"]
+
+
+def test_indexer_site_success_does_not_acknowledge_after_concurrent_failure(monkeypatch):
+    monkeypatch.setattr(
+        "app.services.config.indexer_client_settings.event_service.emit",
+        lambda _event: None,
+    )
+    repo = _FakeIndexerSiteHealthRepository()
+    state = IndexerSiteHealthState(repo=repo)
+
+    for _ in range(3):
+        state.record_failure(
+            indexer_id="prowlarr",
+            indexer_name="Prowlarr",
+            site_id="audiences",
+            site_name="Audiences",
+            error_message="disabled",
+        )
+
+    def write_concurrent_failure():
+        current = repo.find_one("prowlarr", "audiences")
+        assert current is not None
+        repo.upsert(
+            current.model_copy(
+                update={
+                    "status": "unhealthy",
+                    "checked_at": datetime.now() + timedelta(seconds=1),
+                    "notify_pending": True,
+                }
+            )
+        )
+
+    repo.before_acknowledge = write_concurrent_failure
+    recovered = state.record_success(
+        indexer_id="prowlarr",
+        indexer_name="Prowlarr",
+        site_id="audiences",
+        site_name="Audiences",
+    )
+
+    assert recovered.status == "unhealthy"
+    assert recovered.notify_pending is True
+    assert repo.acknowledged_calls == []
 
 
 def test_indexer_site_unhealthy_event_repeats_after_notification_cooldown(monkeypatch):

--- a/backend/tests/test_indexer_site_health_alerts.py
+++ b/backend/tests/test_indexer_site_health_alerts.py
@@ -70,7 +70,11 @@ def test_indexer_site_failure_emits_unhealthy_event_once_at_threshold(monkeypatc
     assert event.message_params["consecutive_failures"] == "3"
 
 
-def test_indexer_site_success_clears_notify_pending_and_allows_future_threshold():
+def test_indexer_site_success_clears_notify_pending_and_allows_future_threshold(monkeypatch):
+    monkeypatch.setattr(
+        "app.services.config.indexer_client_settings.event_service.acknowledge_matching_events",
+        lambda **_kwargs: 0,
+    )
     state = IndexerSiteHealthState(repo=_FakeIndexerSiteHealthRepository())
 
     for _ in range(3):
@@ -113,6 +117,10 @@ def test_indexer_site_unhealthy_event_respects_notification_cooldown(monkeypatch
         "app.services.config.indexer_client_settings.event_service.emit",
         lambda event: emitted_events.append(event),
     )
+    monkeypatch.setattr(
+        "app.services.config.indexer_client_settings.event_service.acknowledge_matching_events",
+        lambda **_kwargs: 0,
+    )
     state = IndexerSiteHealthState(repo=_FakeIndexerSiteHealthRepository())
 
     for _ in range(3):
@@ -139,6 +147,45 @@ def test_indexer_site_unhealthy_event_respects_notification_cooldown(monkeypatch
         )
 
     assert len(emitted_events) == 1
+
+
+def test_indexer_site_success_acknowledges_unhealthy_warning_event(monkeypatch):
+    emitted_events = []
+    acknowledged_calls = []
+    monkeypatch.setattr(
+        "app.services.config.indexer_client_settings.event_service.emit",
+        lambda event: emitted_events.append(event),
+    )
+    monkeypatch.setattr(
+        "app.services.config.indexer_client_settings.event_service.acknowledge_matching_events",
+        lambda **kwargs: acknowledged_calls.append(kwargs) or 1,
+    )
+    state = IndexerSiteHealthState(repo=_FakeIndexerSiteHealthRepository())
+
+    for _ in range(3):
+        state.record_failure(
+            indexer_id="prowlarr",
+            indexer_name="Prowlarr",
+            site_id="audiences",
+            site_name="Audiences",
+            error_message="disabled",
+        )
+
+    state.record_success(
+        indexer_id="prowlarr",
+        indexer_name="Prowlarr",
+        site_id="audiences",
+        site_name="Audiences",
+    )
+
+    assert len(emitted_events) == 1
+    assert acknowledged_calls == [
+        {
+            "correlation_id": "indexer:prowlarr:site:audiences:unhealthy",
+            "types": [EventTypes.INDEXER_SITE_UNHEALTHY],
+            "levels": [EventLevel.warning],
+        }
+    ]
 
 
 def test_indexer_site_unhealthy_event_repeats_after_notification_cooldown(monkeypatch):


### PR DESCRIPTION
## Summary

- add repository and service support for acknowledging events by correlation, type, and level
- acknowledge an indexer-site unhealthy warning when the site recovers
- keep recovery acknowledgement failures isolated from health-state persistence
- cover threshold, cooldown, and recovery behavior

## Root cause

Indexer unhealthy warnings remained visible in the notification center after a successful search restored the site to a healthy state.

## Validation

- `./scripts/review_with_gates.sh`
- Backend quality checks passed
- 233 backend tests passed
- Frontend quality and production build passed

## Risk

Acknowledgement is limited to warning-level unhealthy events with the exact indexer/site correlation ID.