### PR TITLE
Fix season-scoped media mapping merges

### DIFF
--- a/backend/app/command_worker.py
+++ b/backend/app/command_worker.py
@@ -33,6 +33,9 @@ class CommandWorker:
 
         try:
             while not self._stop_event.is_set():
+                recovered = await command_service.recover_next_deferred_command()
+                if recovered:
+                    continue
                 handled = await command_service.run_next_queued_command()
                 if handled:
                     continue

--- a/backend/app/db/repositories/action_repository.py
+++ b/backend/app/db/repositories/action_repository.py
@@ -179,37 +179,41 @@ class ActionRepository:
             }
         )
 
+    @staticmethod
+    def add_to_session(session, action: ActionRecord) -> None:
+        session.add(
+            ActionORM(
+                id=action.id,
+                ts=action.ts.isoformat(),
+                started_at=action.started_at.isoformat() if action.started_at else None,
+                finished_at=action.finished_at.isoformat() if action.finished_at else None,
+                kind=action.kind.value,
+                action_name=action.action_name,
+                status=action.status.value,
+                actor=action.actor.value,
+                trigger=action.trigger.value,
+                source=action.source.value,
+                target_type=action.target_type.value if action.target_type else None,
+                target_id=action.target_id,
+                media_id=str(action.media_id) if action.media_id else None,
+                media_season_number=action.media.season_number if action.media else None,
+                media_title=action.media.title if action.media else None,
+                media_year=action.media.year if action.media else None,
+                task_id=action.task_id,
+                subscription_id=action.subscription_id,
+                correlation_id=action.correlation_id,
+                message_key=action.message_key,
+                message_params_json=action.message_params,
+                error=action.error,
+                search_text=build_action_search_text(action),
+                duration_ms=action.duration_ms,
+                meta_json=ActionRepository._meta_db_value(action.meta),
+            )
+        )
+
     def insert(self, action: ActionRecord) -> str:
         with SessionLocal() as session:
-            session.add(
-                ActionORM(
-                    id=action.id,
-                    ts=action.ts.isoformat(),
-                    started_at=action.started_at.isoformat() if action.started_at else None,
-                    finished_at=action.finished_at.isoformat() if action.finished_at else None,
-                    kind=action.kind.value,
-                    action_name=action.action_name,
-                    status=action.status.value,
-                    actor=action.actor.value,
-                    trigger=action.trigger.value,
-                    source=action.source.value,
-                    target_type=action.target_type.value if action.target_type else None,
-                    target_id=action.target_id,
-                    media_id=str(action.media_id) if action.media_id else None,
-                    media_season_number=action.media.season_number if action.media else None,
-                    media_title=action.media.title if action.media else None,
-                    media_year=action.media.year if action.media else None,
-                    task_id=action.task_id,
-                    subscription_id=action.subscription_id,
-                    correlation_id=action.correlation_id,
-                    message_key=action.message_key,
-                    message_params_json=action.message_params,
-                    error=action.error,
-                    search_text=build_action_search_text(action),
-                    duration_ms=action.duration_ms,
-                    meta_json=self._meta_db_value(action.meta),
-                )
-            )
+            self.add_to_session(session, action)
             session.commit()
             return action.id
 

--- a/backend/app/db/repositories/action_repository.py
+++ b/backend/app/db/repositories/action_repository.py
@@ -211,6 +211,24 @@ class ActionRepository:
             )
         )
 
+    @staticmethod
+    def mark_cancelled_in_session(session, action_ids: list[str], finished_at) -> None:
+        if not action_ids:
+            return
+        rows = session.execute(
+            select(ActionORM).where(
+                ActionORM.id.in_(action_ids),
+                ActionORM.status == ActionStatus.queued.value,
+            )
+        ).scalars().all()
+        for row in rows:
+            action = ActionRepository._to_model(row)
+            action.status = ActionStatus.cancelled
+            action.finished_at = finished_at
+            row.status = action.status.value
+            row.finished_at = finished_at.isoformat()
+            row.search_text = build_action_search_text(action)
+
     def insert(self, action: ActionRecord) -> str:
         with SessionLocal() as session:
             self.add_to_session(session, action)

--- a/backend/app/db/repositories/command_repository.py
+++ b/backend/app/db/repositories/command_repository.py
@@ -302,6 +302,23 @@ class CommandRepository:
             ).scalars().first()
             return self._to_model(row) if row else None
 
+    async def claim_next_queued(self, started_at_iso: str) -> CommandRecord | None:
+        with SessionLocal() as session:
+            session.execute(text("BEGIN IMMEDIATE"))
+            row = session.execute(
+                select(CommandORM)
+                .where(CommandORM.status == CommandStatus.QUEUED.value)
+                .order_by(CommandORM.created_at.asc())
+                .limit(1)
+            ).scalars().first()
+            if row is None:
+                session.rollback()
+                return None
+            row.status = CommandStatus.RUNNING.value
+            row.started_at = started_at_iso
+            session.commit()
+            return self._to_model(row)
+
     async def find_active_filtered(
         self,
         target_type: CommandTargetType | None = None,

--- a/backend/app/db/repositories/command_repository.py
+++ b/backend/app/db/repositories/command_repository.py
@@ -187,6 +187,19 @@ class CommandRepository:
             session.commit()
             return bool(result.rowcount)
 
+    async def reserve_ready_command(self, command_id: str) -> bool:
+        with SessionLocal() as session:
+            result = session.execute(
+                update(CommandORM)
+                .where(
+                    CommandORM.id == command_id,
+                    CommandORM.status == CommandStatus.READY.value,
+                )
+                .values(status=CommandStatus.STAGED.value)
+            )
+            session.commit()
+            return bool(result.rowcount)
+
     async def find_next_ready(self) -> CommandRecord | None:
         with SessionLocal() as session:
             row = session.execute(
@@ -197,18 +210,16 @@ class CommandRepository:
             ).scalars().first()
             return self._to_model(row) if row else None
 
-    async def find_next_expired_staged(self, created_before_iso: str) -> CommandRecord | None:
+    async def delete_expired_staged_commands(self, created_before_iso: str) -> int:
         with SessionLocal() as session:
-            row = session.execute(
-                select(CommandORM)
-                .where(
+            result = session.execute(
+                delete(CommandORM).where(
                     CommandORM.status == CommandStatus.STAGED.value,
                     CommandORM.created_at < created_before_iso,
                 )
-                .order_by(CommandORM.created_at.asc())
-                .limit(1)
-            ).scalars().first()
-            return self._to_model(row) if row else None
+            )
+            session.commit()
+            return int(result.rowcount or 0)
 
     async def delete_staged_command(self, command_id: str) -> bool:
         with SessionLocal() as session:

--- a/backend/app/db/repositories/command_repository.py
+++ b/backend/app/db/repositories/command_repository.py
@@ -3,15 +3,21 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from sqlalchemy import delete, desc, select, update
+from sqlalchemy import delete, desc, select, text, update
 
+from app.db.repositories.action_repository import ActionRepository
 from app.db.sql.models import CommandORM
 from app.db.sql.session import SessionLocal
+from app.schemas.domain.action import ActionRecord
 from app.schemas.domain.command import CommandRecord, CommandStatus, CommandTargetType, CommandType
 
 
 ACTIVE_COMMAND_STATUSES = [
     CommandStatus.STAGED.value,
+    CommandStatus.QUEUED.value,
+    CommandStatus.RUNNING.value,
+]
+DEDUPLICATED_COMMAND_STATUSES = [
     CommandStatus.QUEUED.value,
     CommandStatus.RUNNING.value,
 ]
@@ -145,15 +151,38 @@ class CommandRepository:
             session.commit()
             return bool(result.rowcount)
 
-    async def publish_staged_command(self, command_id: str) -> bool:
+    async def publish_staged_command(
+        self,
+        command: CommandRecord,
+        action: ActionRecord,
+    ) -> bool:
+        with SessionLocal() as session:
+            session.execute(text("BEGIN IMMEDIATE"))
+            row = session.get(CommandORM, command.id)
+            if row is None or row.status != CommandStatus.STAGED.value:
+                session.rollback()
+                return False
+            ActionRepository.add_to_session(session, action)
+            row.status = CommandStatus.QUEUED.value
+            row.message_key = command.message_key
+            row.message_params_json = command.message_params
+            try:
+                session.commit()
+            except Exception:
+                session.rollback()
+                raise
+            return True
+
+    async def delete_expired_staged_commands(self, created_before_iso: str) -> int:
         with SessionLocal() as session:
             result = session.execute(
-                update(CommandORM)
-                .where(CommandORM.id == command_id, CommandORM.status == CommandStatus.STAGED.value)
-                .values(status=CommandStatus.QUEUED.value)
+                delete(CommandORM).where(
+                    CommandORM.status == CommandStatus.STAGED.value,
+                    CommandORM.created_at < created_before_iso,
+                )
             )
             session.commit()
-            return bool(result.rowcount)
+            return int(result.rowcount or 0)
 
     async def delete_staged_command(self, command_id: str) -> bool:
         with SessionLocal() as session:
@@ -251,7 +280,7 @@ class CommandRepository:
                 select(CommandORM)
                 .where(
                     CommandORM.uniq_key == uniq_key,
-                    CommandORM.status.in_(ACTIVE_COMMAND_STATUSES),
+                    CommandORM.status.in_(DEDUPLICATED_COMMAND_STATUSES),
                 )
                 .order_by(desc(CommandORM.created_at))
                 .limit(1)

--- a/backend/app/db/repositories/command_repository.py
+++ b/backend/app/db/repositories/command_repository.py
@@ -13,11 +13,12 @@ from app.schemas.domain.command import CommandRecord, CommandStatus, CommandTarg
 
 
 ACTIVE_COMMAND_STATUSES = [
-    CommandStatus.STAGED.value,
+    CommandStatus.READY.value,
     CommandStatus.QUEUED.value,
     CommandStatus.RUNNING.value,
 ]
 DEDUPLICATED_COMMAND_STATUSES = [
+    CommandStatus.READY.value,
     CommandStatus.QUEUED.value,
     CommandStatus.RUNNING.value,
 ]
@@ -159,7 +160,7 @@ class CommandRepository:
         with SessionLocal() as session:
             session.execute(text("BEGIN IMMEDIATE"))
             row = session.get(CommandORM, command.id)
-            if row is None or row.status != CommandStatus.STAGED.value:
+            if row is None or row.status != CommandStatus.READY.value:
                 session.rollback()
                 return False
             ActionRepository.add_to_session(session, action)
@@ -173,16 +174,41 @@ class CommandRepository:
                 raise
             return True
 
-    async def delete_expired_staged_commands(self, created_before_iso: str) -> int:
+    async def mark_staged_command_ready(self, command_id: str) -> bool:
         with SessionLocal() as session:
             result = session.execute(
-                delete(CommandORM).where(
+                update(CommandORM)
+                .where(
+                    CommandORM.id == command_id,
+                    CommandORM.status == CommandStatus.STAGED.value,
+                )
+                .values(status=CommandStatus.READY.value)
+            )
+            session.commit()
+            return bool(result.rowcount)
+
+    async def find_next_ready(self) -> CommandRecord | None:
+        with SessionLocal() as session:
+            row = session.execute(
+                select(CommandORM)
+                .where(CommandORM.status == CommandStatus.READY.value)
+                .order_by(CommandORM.created_at.asc())
+                .limit(1)
+            ).scalars().first()
+            return self._to_model(row) if row else None
+
+    async def find_next_expired_staged(self, created_before_iso: str) -> CommandRecord | None:
+        with SessionLocal() as session:
+            row = session.execute(
+                select(CommandORM)
+                .where(
                     CommandORM.status == CommandStatus.STAGED.value,
                     CommandORM.created_at < created_before_iso,
                 )
-            )
-            session.commit()
-            return int(result.rowcount or 0)
+                .order_by(CommandORM.created_at.asc())
+                .limit(1)
+            ).scalars().first()
+            return self._to_model(row) if row else None
 
     async def delete_staged_command(self, command_id: str) -> bool:
         with SessionLocal() as session:
@@ -194,14 +220,6 @@ class CommandRepository:
             )
             session.commit()
             return bool(result.rowcount)
-
-    async def delete_all_staged_commands(self) -> int:
-        with SessionLocal() as session:
-            result = session.execute(
-                delete(CommandORM).where(CommandORM.status == CommandStatus.STAGED.value)
-            )
-            session.commit()
-            return int(result.rowcount or 0)
 
     async def find_active(self) -> list[CommandRecord]:
         with SessionLocal() as session:

--- a/backend/app/db/repositories/command_repository.py
+++ b/backend/app/db/repositories/command_repository.py
@@ -3,11 +3,18 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from sqlalchemy import desc, select, update
+from sqlalchemy import delete, desc, select, update
 
 from app.db.sql.models import CommandORM
 from app.db.sql.session import SessionLocal
 from app.schemas.domain.command import CommandRecord, CommandStatus, CommandTargetType, CommandType
+
+
+ACTIVE_COMMAND_STATUSES = [
+    CommandStatus.STAGED.value,
+    CommandStatus.QUEUED.value,
+    CommandStatus.RUNNING.value,
+]
 
 
 class CommandRepository:
@@ -138,11 +145,40 @@ class CommandRepository:
             session.commit()
             return bool(result.rowcount)
 
+    async def publish_staged_command(self, command_id: str) -> bool:
+        with SessionLocal() as session:
+            result = session.execute(
+                update(CommandORM)
+                .where(CommandORM.id == command_id, CommandORM.status == CommandStatus.STAGED.value)
+                .values(status=CommandStatus.QUEUED.value)
+            )
+            session.commit()
+            return bool(result.rowcount)
+
+    async def delete_staged_command(self, command_id: str) -> bool:
+        with SessionLocal() as session:
+            result = session.execute(
+                delete(CommandORM).where(
+                    CommandORM.id == command_id,
+                    CommandORM.status == CommandStatus.STAGED.value,
+                )
+            )
+            session.commit()
+            return bool(result.rowcount)
+
+    async def delete_all_staged_commands(self) -> int:
+        with SessionLocal() as session:
+            result = session.execute(
+                delete(CommandORM).where(CommandORM.status == CommandStatus.STAGED.value)
+            )
+            session.commit()
+            return int(result.rowcount or 0)
+
     async def find_active(self) -> list[CommandRecord]:
         with SessionLocal() as session:
             rows = session.execute(
                 select(CommandORM)
-                .where(CommandORM.status.in_([CommandStatus.QUEUED.value, CommandStatus.RUNNING.value]))
+                .where(CommandORM.status.in_(ACTIVE_COMMAND_STATUSES))
                 .order_by(desc(CommandORM.created_at))
             ).scalars().all()
             return [self._to_model(row) for row in rows]
@@ -175,7 +211,7 @@ class CommandRepository:
     ) -> list[CommandRecord]:
         with SessionLocal() as session:
             stmt = select(CommandORM).where(
-                CommandORM.status.in_([CommandStatus.QUEUED.value, CommandStatus.RUNNING.value])
+                CommandORM.status.in_(ACTIVE_COMMAND_STATUSES)
             )
             if target_type:
                 stmt = stmt.where(CommandORM.target_type == target_type.value)
@@ -199,7 +235,7 @@ class CommandRepository:
         with SessionLocal() as session:
             stmt = select(CommandORM).where(
                 CommandORM.media_id == media_id,
-                CommandORM.status.in_([CommandStatus.QUEUED.value, CommandStatus.RUNNING.value]),
+                CommandORM.status.in_(ACTIVE_COMMAND_STATUSES),
             )
             if target_season_number is not None:
                 stmt = stmt.where(CommandORM.target_season_number == target_season_number)
@@ -215,7 +251,7 @@ class CommandRepository:
                 select(CommandORM)
                 .where(
                     CommandORM.uniq_key == uniq_key,
-                    CommandORM.status.in_([CommandStatus.QUEUED.value, CommandStatus.RUNNING.value]),
+                    CommandORM.status.in_(ACTIVE_COMMAND_STATUSES),
                 )
                 .order_by(desc(CommandORM.created_at))
                 .limit(1)

--- a/backend/app/db/repositories/command_repository.py
+++ b/backend/app/db/repositories/command_repository.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 import json
 from typing import Any
 
+from datetime import datetime
+
 from sqlalchemy import delete, desc, select, text, update
 
 from app.db.repositories.action_repository import ActionRepository
-from app.db.sql.models import CommandORM
+from app.db.sql.models import ActionORM, CommandORM
 from app.db.sql.session import SessionLocal
 from app.schemas.domain.action import ActionRecord
 from app.schemas.domain.command import CommandRecord, CommandStatus, CommandTargetType, CommandType
@@ -186,6 +188,52 @@ class CommandRepository:
             )
             session.commit()
             return bool(result.rowcount)
+
+    def finalize_staged_replacement(self, command_id: str, before_ready) -> None:
+        with SessionLocal.begin() as session:
+            before_ready(session)
+            self._finalize_staged_replacement(session, command_id)
+
+    @staticmethod
+    def _finalize_staged_replacement(session, command_id: str) -> None:
+        row = session.get(CommandORM, command_id)
+        if row is None or row.status != CommandStatus.STAGED.value:
+            raise RuntimeError(f"Staged command disappeared before finalization: {command_id}")
+
+        finished_at = datetime.now().isoformat()
+        superseded_ids = [
+            item[0]
+            for item in session.execute(
+                select(CommandORM.id).where(
+                    CommandORM.uniq_key == row.uniq_key,
+                    CommandORM.status == CommandStatus.QUEUED.value,
+                    CommandORM.id != command_id,
+                )
+            ).all()
+        ]
+        if superseded_ids:
+            session.execute(
+                update(CommandORM)
+                .where(CommandORM.id.in_(superseded_ids))
+                .values(
+                    status=CommandStatus.CANCELLED.value,
+                    message_key=None,
+                    message_params_json={},
+                    error=None,
+                    error_key=None,
+                    error_params_json={},
+                    finished_at=finished_at,
+                )
+            )
+            session.execute(
+                update(ActionORM)
+                .where(
+                    ActionORM.id.in_(superseded_ids),
+                    ActionORM.status == "queued",
+                )
+                .values(status="cancelled", finished_at=finished_at)
+            )
+        row.status = CommandStatus.READY.value
 
     async def reserve_ready_command(self, command_id: str) -> bool:
         with SessionLocal() as session:

--- a/backend/app/db/repositories/command_repository.py
+++ b/backend/app/db/repositories/command_repository.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from sqlalchemy import delete, desc, select, text, update
 
 from app.db.repositories.action_repository import ActionRepository
-from app.db.sql.models import ActionORM, CommandORM
+from app.db.sql.models import CommandORM
 from app.db.sql.session import SessionLocal
 from app.schemas.domain.action import ActionRecord
 from app.schemas.domain.command import CommandRecord, CommandStatus, CommandTargetType, CommandType
@@ -207,13 +207,16 @@ class CommandRepository:
 
     @staticmethod
     def _finalize_staged_replacement(session, row: CommandORM) -> None:
-        finished_at = datetime.now().isoformat()
+        finished_at = datetime.now()
         superseded_ids = [
             item[0]
             for item in session.execute(
                 select(CommandORM.id).where(
                     CommandORM.uniq_key == row.uniq_key,
-                    CommandORM.status == CommandStatus.QUEUED.value,
+                    CommandORM.status.in_([
+                        CommandStatus.READY.value,
+                        CommandStatus.QUEUED.value,
+                    ]),
                     CommandORM.id != row.id,
                 )
             ).all()
@@ -229,16 +232,13 @@ class CommandRepository:
                     error=None,
                     error_key=None,
                     error_params_json={},
-                    finished_at=finished_at,
+                    finished_at=finished_at.isoformat(),
                 )
             )
-            session.execute(
-                update(ActionORM)
-                .where(
-                    ActionORM.id.in_(superseded_ids),
-                    ActionORM.status == "queued",
-                )
-                .values(status="cancelled", finished_at=finished_at)
+            ActionRepository.mark_cancelled_in_session(
+                session,
+                superseded_ids,
+                finished_at,
             )
         row.status = CommandStatus.READY.value
 

--- a/backend/app/db/repositories/command_repository.py
+++ b/backend/app/db/repositories/command_repository.py
@@ -189,17 +189,24 @@ class CommandRepository:
             session.commit()
             return bool(result.rowcount)
 
-    def finalize_staged_replacement(self, command_id: str, before_ready) -> None:
+    def finalize_staged_replacement(self, command_id: str, before_ready) -> CommandRecord:
         with SessionLocal.begin() as session:
+            row = session.get(CommandORM, command_id)
+            if row is None or row.status not in {
+                CommandStatus.STAGED.value,
+                CommandStatus.READY.value,
+            }:
+                raise RuntimeError(
+                    f"Deferred command is no longer available for finalization: {command_id}"
+                )
             before_ready(session)
-            self._finalize_staged_replacement(session, command_id)
+            session.refresh(row)
+            self._finalize_staged_replacement(session, row)
+            session.flush()
+            return self._to_model(row)
 
     @staticmethod
-    def _finalize_staged_replacement(session, command_id: str) -> None:
-        row = session.get(CommandORM, command_id)
-        if row is None or row.status != CommandStatus.STAGED.value:
-            raise RuntimeError(f"Staged command disappeared before finalization: {command_id}")
-
+    def _finalize_staged_replacement(session, row: CommandORM) -> None:
         finished_at = datetime.now().isoformat()
         superseded_ids = [
             item[0]
@@ -207,7 +214,7 @@ class CommandRepository:
                 select(CommandORM.id).where(
                     CommandORM.uniq_key == row.uniq_key,
                     CommandORM.status == CommandStatus.QUEUED.value,
-                    CommandORM.id != command_id,
+                    CommandORM.id != row.id,
                 )
             ).all()
         ]
@@ -234,19 +241,6 @@ class CommandRepository:
                 .values(status="cancelled", finished_at=finished_at)
             )
         row.status = CommandStatus.READY.value
-
-    async def reserve_ready_command(self, command_id: str) -> bool:
-        with SessionLocal() as session:
-            result = session.execute(
-                update(CommandORM)
-                .where(
-                    CommandORM.id == command_id,
-                    CommandORM.status == CommandStatus.READY.value,
-                )
-                .values(status=CommandStatus.STAGED.value)
-            )
-            session.commit()
-            return bool(result.rowcount)
 
     async def find_next_ready(self) -> CommandRecord | None:
         with SessionLocal() as session:

--- a/backend/app/db/repositories/media_external_mapping_repository.py
+++ b/backend/app/db/repositories/media_external_mapping_repository.py
@@ -218,15 +218,22 @@ class MediaExternalMappingRepository:
             )
             session.commit()
 
-    def remove(self, media_id: MediaID, season_number: int | None = None) -> bool:
-        with SessionLocal() as session:
-            statement = delete(MediaExternalMappingORM).where(MediaExternalMappingORM.media_id == str(media_id))
-            if media_id.media_type.value == "tv":
-                if season_number is None or season_number <= 0:
-                    return False
-                statement = statement.where(MediaExternalMappingORM.season_number == int(season_number))
-            else:
-                statement = statement.where(MediaExternalMappingORM.season_number == 0)
-            result = session.execute(statement)
-            session.commit()
-            return bool(result.rowcount)
+    def remove(self, media_id: MediaID, season_number: int | None = None, *, session=None) -> bool:
+        if session is None:
+            with SessionLocal() as owned_session:
+                removed = self._remove(owned_session, media_id, season_number)
+                owned_session.commit()
+                return removed
+        return self._remove(session, media_id, season_number)
+
+    @staticmethod
+    def _remove(session, media_id: MediaID, season_number: int | None = None) -> bool:
+        statement = delete(MediaExternalMappingORM).where(MediaExternalMappingORM.media_id == str(media_id))
+        if media_id.media_type.value == "tv":
+            if season_number is None or season_number <= 0:
+                return False
+            statement = statement.where(MediaExternalMappingORM.season_number == int(season_number))
+        else:
+            statement = statement.where(MediaExternalMappingORM.season_number == 0)
+        result = session.execute(statement)
+        return bool(result.rowcount)

--- a/backend/app/db/repositories/media_identity_repository.py
+++ b/backend/app/db/repositories/media_identity_repository.py
@@ -12,76 +12,84 @@ from app.schemas.media_id import MediaID, Provider
 
 
 class MediaIdentityRepository:
-    def merge_media_id(self, source_media_id: MediaID, target_media_id: MediaID) -> None:
+    def merge_media_id(self, source_media_id: MediaID, target_media_id: MediaID, *, session=None) -> None:
         if source_media_id == target_media_id:
             return
+
+        if session is None:
+            with SessionLocal.begin() as owned_session:
+                self._merge_media_id(owned_session, source_media_id, target_media_id)
+            return
+
+        self._merge_media_id(session, source_media_id, target_media_id)
+
+    def _merge_media_id(self, session, source_media_id: MediaID, target_media_id: MediaID) -> None:
 
         source = str(source_media_id)
         target = str(target_media_id)
         target_provider = target_media_id.provider.value
         target_provider_item_id = target_media_id.id
 
-        with SessionLocal.begin() as session:
-            self._replace_embedded_media_refs(session, source_media_id, target_media_id)
-            self._merge_singleton_rows(session, source, target)
-            self._merge_subscription_settings(session, source, target)
-            self._merge_metadata_sync(session, source, target)
+        self._replace_embedded_media_refs(session, source_media_id, target_media_id)
+        self._merge_singleton_rows(session, source, target)
+        self._merge_subscription_settings(session, source, target)
+        self._merge_metadata_sync(session, source, target)
 
-            for table in (
-                "library_files",
-                "library_episodes",
-                "actions",
-                "events",
-                "media_subscription_cycles",
-            ):
-                session.execute(text(f"UPDATE {table} SET media_id = :target WHERE media_id = :source"), {"source": source, "target": target})
+        for table in (
+            "library_files",
+            "library_episodes",
+            "actions",
+            "events",
+            "media_subscription_cycles",
+        ):
+            session.execute(text(f"UPDATE {table} SET media_id = :target WHERE media_id = :source"), {"source": source, "target": target})
 
-            session.execute(
-                text(
-                    """
-                    UPDATE tasks
-                    SET media_id = :target,
-                        provider = :provider,
-                        provider_item_id = :provider_item_id
-                    WHERE media_id = :source
-                    """
-                ),
-                {
-                    "source": source,
-                    "target": target,
-                    "provider": target_provider,
-                    "provider_item_id": target_provider_item_id,
-                },
-            )
-            session.execute(
-                text(
-                    """
-                    UPDATE commands
-                    SET media_id = :target,
-                        target_id = CASE WHEN target_type = 'media' AND target_id = :source THEN :target ELSE target_id END
-                    WHERE media_id = :source OR (target_type = 'media' AND target_id = :source)
-                    """
-                ),
-                {"source": source, "target": target},
-            )
+        session.execute(
+            text(
+                """
+                UPDATE tasks
+                SET media_id = :target,
+                    provider = :provider,
+                    provider_item_id = :provider_item_id
+                WHERE media_id = :source
+                """
+            ),
+            {
+                "source": source,
+                "target": target,
+                "provider": target_provider,
+                "provider_item_id": target_provider_item_id,
+            },
+        )
+        session.execute(
+            text(
+                """
+                UPDATE commands
+                SET media_id = :target,
+                    target_id = CASE WHEN target_type = 'media' AND target_id = :source THEN :target ELSE target_id END
+                WHERE media_id = :source OR (target_type = 'media' AND target_id = :source)
+                """
+            ),
+            {"source": source, "target": target},
+        )
 
-            self._retarget_source_mapping(session, source_media_id, target_media_id)
-            session.execute(
-                text(
-                    """
-                    UPDATE media_external_mappings
-                    SET media_id = :target,
-                        tmdb_id = CASE WHEN :target_provider = 'tmdb' THEN :target_tmdb_id ELSE tmdb_id END
-                    WHERE media_id = :source
-                    """
-                ),
-                {
-                    "source": source,
-                    "target": target,
-                    "target_provider": target_provider,
-                    "target_tmdb_id": int(target_media_id.id) if target_media_id.provider == Provider.tmdb else None,
-                },
-            )
+        self._retarget_source_mapping(session, source_media_id, target_media_id)
+        session.execute(
+            text(
+                """
+                UPDATE media_external_mappings
+                SET media_id = :target,
+                    tmdb_id = CASE WHEN :target_provider = 'tmdb' THEN :target_tmdb_id ELSE tmdb_id END
+                WHERE media_id = :source
+                """
+            ),
+            {
+                "source": source,
+                "target": target,
+                "target_provider": target_provider,
+                "target_tmdb_id": int(target_media_id.id) if target_media_id.provider == Provider.tmdb else None,
+            },
+        )
 
     def _retarget_source_mapping(self, session, source_media_id: MediaID, target_media_id: MediaID) -> None:
         target_tmdb_id = int(target_media_id.id) if target_media_id.provider == Provider.tmdb else None

--- a/backend/app/db/repositories/media_identity_repository.py
+++ b/backend/app/db/repositories/media_identity_repository.py
@@ -103,6 +103,23 @@ class MediaIdentityRepository:
         session.execute(
             text(
                 f"""
+                DELETE FROM media_external_mappings
+                WHERE {source_predicate}
+                  AND media_type = :media_type
+                  AND media_id != :target
+                  AND EXISTS (
+                    SELECT 1
+                    FROM media_external_mappings target_rows
+                    WHERE target_rows.media_id = :target
+                      AND target_rows.season_number = media_external_mappings.season_number
+                  )
+                """
+            ),
+            params,
+        )
+        session.execute(
+            text(
+                f"""
                 UPDATE media_external_mappings
                 SET media_id = :target,
                     tmdb_id = CASE WHEN :target_tmdb_id IS NOT NULL THEN :target_tmdb_id ELSE tmdb_id END,

--- a/backend/app/db/repositories/media_identity_repository.py
+++ b/backend/app/db/repositories/media_identity_repository.py
@@ -85,7 +85,7 @@ class MediaIdentityRepository:
 
     def _retarget_source_mapping(self, session, source_media_id: MediaID, target_media_id: MediaID) -> None:
         target_tmdb_id = int(target_media_id.id) if target_media_id.provider == Provider.tmdb else None
-        source_predicate = None
+        source_column = None
         params = {
             "target": str(target_media_id),
             "target_tmdb_id": target_tmdb_id,
@@ -93,30 +93,77 @@ class MediaIdentityRepository:
             "media_type": source_media_id.media_type.value,
         }
         if source_media_id.provider == Provider.douban:
-            source_predicate = "douban_id = :source_external_id"
+            source_column = "douban_id"
+            source_parameter = "source_external_id"
             params["source_external_id"] = source_media_id.id
         elif source_media_id.provider == Provider.tmdb:
-            source_predicate = "tmdb_id = :source_tmdb_id"
+            source_column = "tmdb_id"
+            source_parameter = "source_tmdb_id"
             params["source_tmdb_id"] = int(source_media_id.id)
-        if not source_predicate:
+        if not source_column:
             return
-        session.execute(
+        source_predicate = f"{source_column} = :{source_parameter}"
+        conflicts = session.execute(
             text(
                 f"""
-                DELETE FROM media_external_mappings
-                WHERE {source_predicate}
-                  AND media_type = :media_type
-                  AND media_id != :target
-                  AND EXISTS (
-                    SELECT 1
-                    FROM media_external_mappings target_rows
-                    WHERE target_rows.media_id = :target
-                      AND target_rows.season_number = media_external_mappings.season_number
-                  )
+                SELECT source_rows.media_id AS source_media_id,
+                       source_rows.season_number AS season_number,
+                       source_rows.imdb_id AS source_imdb_id,
+                       source_rows.douban_id AS source_douban_id,
+                       source_rows.episode_count_override AS source_episode_count_override,
+                       target_rows.imdb_id AS target_imdb_id,
+                       target_rows.douban_id AS target_douban_id,
+                       target_rows.episode_count_override AS target_episode_count_override
+                FROM media_external_mappings source_rows
+                JOIN media_external_mappings target_rows
+                  ON target_rows.media_id = :target
+                 AND target_rows.season_number = source_rows.season_number
+                WHERE source_rows.{source_predicate}
+                  AND source_rows.media_type = :media_type
+                  AND source_rows.media_id != :target
                 """
             ),
             params,
-        )
+        ).mappings().all()
+        for conflict in conflicts:
+            session.execute(
+                text(
+                    """
+                    DELETE FROM media_external_mappings
+                    WHERE media_id = :source_media_id
+                      AND season_number = :season_number
+                    """
+                ),
+                {
+                    "source_media_id": conflict["source_media_id"],
+                    "season_number": conflict["season_number"],
+                },
+            )
+            session.execute(
+                text(
+                    """
+                    UPDATE media_external_mappings
+                    SET imdb_id = :imdb_id,
+                        douban_id = :douban_id,
+                        episode_count_override = :episode_count_override,
+                        updated_at = :updated_at
+                    WHERE media_id = :target
+                      AND season_number = :season_number
+                    """
+                ),
+                {
+                    "target": str(target_media_id),
+                    "season_number": conflict["season_number"],
+                    "imdb_id": conflict["target_imdb_id"] or conflict["source_imdb_id"],
+                    "douban_id": conflict["target_douban_id"] or conflict["source_douban_id"],
+                    "episode_count_override": (
+                        conflict["target_episode_count_override"]
+                        if conflict["target_episode_count_override"] is not None
+                        else conflict["source_episode_count_override"]
+                    ),
+                    "updated_at": params["updated_at"],
+                },
+            )
         session.execute(
             text(
                 f"""

--- a/backend/app/db/repositories/media_identity_repository.py
+++ b/backend/app/db/repositories/media_identity_repository.py
@@ -121,11 +121,26 @@ class MediaIdentityRepository:
                 WHERE source_rows.{source_predicate}
                   AND source_rows.media_type = :media_type
                   AND source_rows.media_id != :target
+                ORDER BY source_rows.media_id ASC
                 """
             ),
             params,
         ).mappings().all()
+        merged_by_season: dict[int, dict[str, Any]] = {}
         for conflict in conflicts:
+            season_number = int(conflict["season_number"])
+            merged = merged_by_season.setdefault(
+                season_number,
+                {
+                    "imdb_id": conflict["target_imdb_id"],
+                    "douban_id": conflict["target_douban_id"],
+                    "episode_count_override": conflict["target_episode_count_override"],
+                },
+            )
+            merged["imdb_id"] = merged["imdb_id"] or conflict["source_imdb_id"]
+            merged["douban_id"] = merged["douban_id"] or conflict["source_douban_id"]
+            if merged["episode_count_override"] is None:
+                merged["episode_count_override"] = conflict["source_episode_count_override"]
             session.execute(
                 text(
                     """
@@ -139,6 +154,7 @@ class MediaIdentityRepository:
                     "season_number": conflict["season_number"],
                 },
             )
+        for season_number, merged in merged_by_season.items():
             session.execute(
                 text(
                     """
@@ -153,14 +169,10 @@ class MediaIdentityRepository:
                 ),
                 {
                     "target": str(target_media_id),
-                    "season_number": conflict["season_number"],
-                    "imdb_id": conflict["target_imdb_id"] or conflict["source_imdb_id"],
-                    "douban_id": conflict["target_douban_id"] or conflict["source_douban_id"],
-                    "episode_count_override": (
-                        conflict["target_episode_count_override"]
-                        if conflict["target_episode_count_override"] is not None
-                        else conflict["source_episode_count_override"]
-                    ),
+                    "season_number": season_number,
+                    "imdb_id": merged["imdb_id"],
+                    "douban_id": merged["douban_id"],
+                    "episode_count_override": merged["episode_count_override"],
                     "updated_at": params["updated_at"],
                 },
             )

--- a/backend/app/db/repositories/media_profile_scope_repository.py
+++ b/backend/app/db/repositories/media_profile_scope_repository.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from sqlalchemy import delete, select
+from sqlalchemy import delete, select, update
 
 from app.db.sql.models import MediaProfileScopeORM
 from app.db.sql.session import SessionLocal
@@ -109,6 +109,32 @@ class MediaProfileScopeRepository:
                     setattr(row, key, value)
             session.commit()
             return True
+
+    async def update_mapping_snapshot(
+        self,
+        media_id: MediaID,
+        season_number: int,
+        *,
+        douban_id: str | None = None,
+        episode_count_override: int | None = None,
+        updated_at: float,
+    ) -> bool:
+        values = {"updated_at": updated_at}
+        if douban_id is not None:
+            values["douban_id"] = douban_id
+        if episode_count_override is not None:
+            values["episode_count_override"] = episode_count_override
+        with SessionLocal() as session:
+            result = session.execute(
+                update(MediaProfileScopeORM)
+                .where(
+                    MediaProfileScopeORM.media_id == str(media_id),
+                    MediaProfileScopeORM.season_number == int(season_number),
+                )
+                .values(**values)
+            )
+            session.commit()
+            return bool(result.rowcount)
 
     async def upsert_scopes(self, scopes: list[MediaProfileScope]) -> bool:
         for scope in scopes:

--- a/backend/app/schemas/domain/command.py
+++ b/backend/app/schemas/domain/command.py
@@ -35,6 +35,7 @@ class CommandType(str, Enum):
 
 class CommandStatus(str, Enum):
     STAGED = "staged"
+    READY = "ready"
     QUEUED = "queued"
     RUNNING = "running"
     SUCCEEDED = "succeeded"

--- a/backend/app/schemas/domain/command.py
+++ b/backend/app/schemas/domain/command.py
@@ -138,6 +138,7 @@ class TaskDeleteCommandRequestPayload(PayloadBase):
 
 class ProfileRefreshCommandRequestPayload(PayloadBase):
     target: MediaTarget
+    target_label: str | None = None
 
 
 class MediaDeleteCommandRequestPayload(PayloadBase):

--- a/backend/app/schemas/domain/command.py
+++ b/backend/app/schemas/domain/command.py
@@ -34,6 +34,7 @@ class CommandType(str, Enum):
 
 
 class CommandStatus(str, Enum):
+    STAGED = "staged"
     QUEUED = "queued"
     RUNNING = "running"
     SUCCEEDED = "succeeded"

--- a/backend/app/services/application/commands/handlers/profile.py
+++ b/backend/app/services/application/commands/handlers/profile.py
@@ -22,11 +22,13 @@ class ProfileRefreshCommandHandler:
         request = body.payload
         target = request.target
         payload = ProfileRefreshCommandRecordPayload(target=target)
-        media = await media_service.resolve_execution_snapshot(
-            target.media_id,
-            season_number=target.season_number,
-        )
-        target_label = format_media_target_label(media)
+        target_label = request.target_label
+        if not target_label:
+            media = await media_service.resolve_execution_snapshot(
+                target.media_id,
+                season_number=target.season_number,
+            )
+            target_label = format_media_target_label(media)
         season_part = f":season={target.season_number}" if target.season_number is not None and target.season_number > 0 else ":season=all"
         return CommandRecord(
             id=str(uuid.uuid4()),

--- a/backend/app/services/application/commands/handlers/profile.py
+++ b/backend/app/services/application/commands/handlers/profile.py
@@ -4,6 +4,7 @@ import uuid
 
 from app.schemas.domain.command import (
     CommandCreateRequest,
+    CommandInitiator,
     CommandRecord,
     CommandResult,
     CommandTargetType,
@@ -22,7 +23,7 @@ class ProfileRefreshCommandHandler:
         request = body.payload
         target = request.target
         payload = ProfileRefreshCommandRecordPayload(target=target)
-        target_label = request.target_label
+        target_label = request.target_label if body.initiator == CommandInitiator.SYSTEM else None
         if not target_label:
             media = await media_service.resolve_execution_snapshot(
                 target.media_id,

--- a/backend/app/services/application/commands/message_i18n.py
+++ b/backend/app/services/application/commands/message_i18n.py
@@ -26,6 +26,7 @@ COMMAND_KEY_BY_TYPE = {
 }
 
 STATUS_KEY_BY_STATUS = {
+    CommandStatus.STAGED: "queued",
     CommandStatus.QUEUED: "queued",
     CommandStatus.RUNNING: "running",
     CommandStatus.SUCCEEDED: "succeeded",

--- a/backend/app/services/application/commands/message_i18n.py
+++ b/backend/app/services/application/commands/message_i18n.py
@@ -27,6 +27,7 @@ COMMAND_KEY_BY_TYPE = {
 
 STATUS_KEY_BY_STATUS = {
     CommandStatus.STAGED: "queued",
+    CommandStatus.READY: "queued",
     CommandStatus.QUEUED: "queued",
     CommandStatus.RUNNING: "running",
     CommandStatus.SUCCEEDED: "succeeded",

--- a/backend/app/services/application/commands/service.py
+++ b/backend/app/services/application/commands/service.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from app.core.action_context import action_context
 from app.db.repositories.command_repository import CommandRepository
@@ -28,6 +28,7 @@ from app.services.application.commands.setup import create_command_handler_regis
 from app.schemas.constants.event_types import EventTypes
 
 logger = logging.getLogger("app.services.command")
+STAGED_COMMAND_MAX_AGE = timedelta(hours=24)
 
 class CommandConflictException(Exception):
     pass
@@ -48,7 +49,11 @@ class CommandService:
         await self.reset_running_commands()
 
     async def reset_running_commands(self) -> None:
-        await self.repo.delete_all_staged_commands()
+        expired_count = await self.repo.delete_expired_staged_commands(
+            (datetime.now() - STAGED_COMMAND_MAX_AGE).isoformat()
+        )
+        if expired_count:
+            logger.info("Removed %d expired staged commands", expired_count)
         running_commands = await self.repo.find_running()
         for command in running_commands:
             command.status = CommandStatus.FAILED
@@ -117,16 +122,21 @@ class CommandService:
         *,
         source: ActionSource,
     ) -> CommandRecord:
-        published = await self.repo.publish_staged_command(command_id)
         command = await self.repo.find_by_id(command_id)
         if not command:
             raise RuntimeError(f"Staged command disappeared before publish: {command_id}")
-        if published:
-            command.status = CommandStatus.QUEUED
-            attach_command_message_i18n(command)
-            await self.repo.update(command, self.repo.cond_id(command.id))
-            self._create_command_action(command, source=source)
-        return attach_command_message_i18n(command)
+        if command.status != CommandStatus.STAGED:
+            return attach_command_message_i18n(command)
+        command.status = CommandStatus.QUEUED
+        attach_command_message_i18n(command)
+        action = self._build_command_action(command, source=source, persist=False)
+        published = await self.repo.publish_staged_command(command, action)
+        if not published:
+            latest = await self.repo.find_by_id(command_id)
+            if not latest:
+                raise RuntimeError(f"Staged command disappeared before publish: {command_id}")
+            return attach_command_message_i18n(latest)
+        return command
 
     async def discard_staged_command(self, command_id: str) -> bool:
         return await self.repo.delete_staged_command(command_id)
@@ -288,7 +298,13 @@ class CommandService:
                 self._create_command_action(command, source=source)
             return attach_command_message_i18n(command)
 
-    def _create_command_action(self, command: CommandRecord, source: ActionSource) -> ActionRecord:
+    def _build_command_action(
+        self,
+        command: CommandRecord,
+        source: ActionSource,
+        *,
+        persist: bool,
+    ) -> ActionRecord:
         actor = ActionActor.user if command.initiator == CommandInitiator.MANUAL else ActionActor.system
         if command.initiator == CommandInitiator.MANUAL:
             trigger = ActionTrigger.manual
@@ -316,7 +332,11 @@ class CommandService:
                 target_label=command.target_label,
             ),
             action_id=command.id,
+            persist=persist,
         )
+
+    def _create_command_action(self, command: CommandRecord, source: ActionSource) -> ActionRecord:
+        return self._build_command_action(command, source, persist=True)
 
     def _mark_command_running(self, command: CommandRecord) -> ActionRecord | None:
         return action_service.mark_running(

--- a/backend/app/services/application/commands/service.py
+++ b/backend/app/services/application/commands/service.py
@@ -144,6 +144,13 @@ class CommandService:
             command.status = CommandStatus.STAGED
         return attach_command_message_i18n(command)
 
+    async def finalize_staged_replacement(self, command_id: str, before_ready) -> CommandRecord:
+        self.repo.finalize_staged_replacement(command_id, before_ready)
+        command = await self.repo.find_by_id(command_id)
+        if not command:
+            raise RuntimeError(f"Staged command disappeared after finalization: {command_id}")
+        return attach_command_message_i18n(command)
+
     async def publish_staged_command(
         self,
         command_id: str,

--- a/backend/app/services/application/commands/service.py
+++ b/backend/app/services/application/commands/service.py
@@ -48,6 +48,7 @@ class CommandService:
         await self.reset_running_commands()
 
     async def reset_running_commands(self) -> None:
+        await self.repo.delete_all_staged_commands()
         running_commands = await self.repo.find_running()
         for command in running_commands:
             command.status = CommandStatus.FAILED
@@ -78,6 +79,11 @@ class CommandService:
             source=ActionSource.api,
         )
 
+    async def create_staged_command(self, body: CommandCreateRequest) -> CommandRecord:
+        command = await self._get_registry().build_command(body)
+        command.status = CommandStatus.STAGED
+        return await self._submit_command(command, source=ActionSource.api, create_action=False)
+
     async def find_active_command_by_uniq_key(self, uniq_key: str) -> CommandRecord | None:
         command = await self.repo.find_active_by_uniq_key(uniq_key)
         return attach_command_message_i18n(command) if command else None
@@ -92,6 +98,38 @@ class CommandService:
         command = await self._get_registry().build_command(body)
         command.uniq_key = uniq_key
         return await self._submit_command(command, source=source)
+
+    async def create_staged_command_with_uniq_key(
+        self,
+        body: CommandCreateRequest,
+        *,
+        uniq_key: str,
+        source: ActionSource,
+    ) -> CommandRecord:
+        command = await self._get_registry().build_command(body)
+        command.status = CommandStatus.STAGED
+        command.uniq_key = uniq_key
+        return await self._submit_command(command, source=source, create_action=False)
+
+    async def publish_staged_command(
+        self,
+        command_id: str,
+        *,
+        source: ActionSource,
+    ) -> CommandRecord:
+        published = await self.repo.publish_staged_command(command_id)
+        command = await self.repo.find_by_id(command_id)
+        if not command:
+            raise RuntimeError(f"Staged command disappeared before publish: {command_id}")
+        if published:
+            command.status = CommandStatus.QUEUED
+            attach_command_message_i18n(command)
+            await self.repo.update(command, self.repo.cond_id(command.id))
+            self._create_command_action(command, source=source)
+        return attach_command_message_i18n(command)
+
+    async def discard_staged_command(self, command_id: str) -> bool:
+        return await self.repo.delete_staged_command(command_id)
 
     async def get_command(self, command_id: str) -> CommandRecord | None:
         command = await self.repo.find_by_id(command_id)
@@ -219,11 +257,18 @@ class CommandService:
 
         return True
 
-    async def _submit_command(self, command: CommandRecord, source: ActionSource) -> CommandRecord:
+    async def _submit_command(
+        self,
+        command: CommandRecord,
+        source: ActionSource,
+        *,
+        create_action: bool = True,
+    ) -> CommandRecord:
         if not command.uniq_key:
             attach_command_message_i18n(command)
             await self.repo.insert(command)
-            self._create_command_action(command, source=source)
+            if create_action:
+                self._create_command_action(command, source=source)
             return attach_command_message_i18n(command)
 
         lock = self._uniq_key_locks.setdefault(command.uniq_key, asyncio.Lock())
@@ -239,7 +284,8 @@ class CommandService:
                 return attach_command_message_i18n(existing)
             attach_command_message_i18n(command)
             await self.repo.insert(command)
-            self._create_command_action(command, source=source)
+            if create_action:
+                self._create_command_action(command, source=source)
             return attach_command_message_i18n(command)
 
     def _create_command_action(self, command: CommandRecord, source: ActionSource) -> ActionRecord:

--- a/backend/app/services/application/commands/service.py
+++ b/backend/app/services/application/commands/service.py
@@ -252,11 +252,10 @@ class CommandService:
         return None
 
     async def run_next_queued_command(self) -> bool:
-        command = await self.repo.find_next_queued()
+        started_at = datetime.now()
+        command = await self.repo.claim_next_queued(started_at.isoformat())
         if not command:
             return False
-        command.status = CommandStatus.RUNNING
-        command.started_at = datetime.now()
         attach_command_message_i18n(command)
         await self.repo.update(command, self.repo.cond_id(command.id))
         command_action = self._mark_command_running(command)

--- a/backend/app/services/application/commands/service.py
+++ b/backend/app/services/application/commands/service.py
@@ -135,20 +135,8 @@ class CommandService:
             command.status = CommandStatus.READY
         return attach_command_message_i18n(command)
 
-    async def reserve_ready_command(self, command_id: str) -> CommandRecord:
-        reserved = await self.repo.reserve_ready_command(command_id)
-        command = await self.repo.find_by_id(command_id)
-        if not command:
-            raise RuntimeError(f"Ready command disappeared before reserve: {command_id}")
-        if reserved:
-            command.status = CommandStatus.STAGED
-        return attach_command_message_i18n(command)
-
     async def finalize_staged_replacement(self, command_id: str, before_ready) -> CommandRecord:
-        self.repo.finalize_staged_replacement(command_id, before_ready)
-        command = await self.repo.find_by_id(command_id)
-        if not command:
-            raise RuntimeError(f"Staged command disappeared after finalization: {command_id}")
+        command = self.repo.finalize_staged_replacement(command_id, before_ready)
         return attach_command_message_i18n(command)
 
     async def publish_staged_command(

--- a/backend/app/services/application/commands/service.py
+++ b/backend/app/services/application/commands/service.py
@@ -28,7 +28,7 @@ from app.services.application.commands.setup import create_command_handler_regis
 from app.schemas.constants.event_types import EventTypes
 
 logger = logging.getLogger("app.services.command")
-STAGED_COMMAND_MAX_AGE = timedelta(hours=24)
+STAGED_COMMAND_LEASE = timedelta(minutes=5)
 
 class CommandConflictException(Exception):
     pass
@@ -49,11 +49,6 @@ class CommandService:
         await self.reset_running_commands()
 
     async def reset_running_commands(self) -> None:
-        expired_count = await self.repo.delete_expired_staged_commands(
-            (datetime.now() - STAGED_COMMAND_MAX_AGE).isoformat()
-        )
-        if expired_count:
-            logger.info("Removed %d expired staged commands", expired_count)
         running_commands = await self.repo.find_running()
         for command in running_commands:
             command.status = CommandStatus.FAILED
@@ -87,7 +82,12 @@ class CommandService:
     async def create_staged_command(self, body: CommandCreateRequest) -> CommandRecord:
         command = await self._get_registry().build_command(body)
         command.status = CommandStatus.STAGED
-        return await self._submit_command(command, source=ActionSource.api, create_action=False)
+        return await self._submit_command(
+            command,
+            source=ActionSource.api,
+            create_action=False,
+            deduplicate=False,
+        )
 
     async def find_active_command_by_uniq_key(self, uniq_key: str) -> CommandRecord | None:
         command = await self.repo.find_active_by_uniq_key(uniq_key)
@@ -114,7 +114,21 @@ class CommandService:
         command = await self._get_registry().build_command(body)
         command.status = CommandStatus.STAGED
         command.uniq_key = uniq_key
-        return await self._submit_command(command, source=source, create_action=False)
+        return await self._submit_command(
+            command,
+            source=source,
+            create_action=False,
+            deduplicate=False,
+        )
+
+    async def mark_staged_command_ready(self, command_id: str) -> CommandRecord:
+        marked = await self.repo.mark_staged_command_ready(command_id)
+        command = await self.repo.find_by_id(command_id)
+        if not command:
+            raise RuntimeError(f"Staged command disappeared before ready: {command_id}")
+        if marked:
+            command.status = CommandStatus.READY
+        return attach_command_message_i18n(command)
 
     async def publish_staged_command(
         self,
@@ -125,7 +139,7 @@ class CommandService:
         command = await self.repo.find_by_id(command_id)
         if not command:
             raise RuntimeError(f"Staged command disappeared before publish: {command_id}")
-        if command.status != CommandStatus.STAGED:
+        if command.status != CommandStatus.READY:
             return attach_command_message_i18n(command)
         command.status = CommandStatus.QUEUED
         attach_command_message_i18n(command)
@@ -137,6 +151,26 @@ class CommandService:
                 raise RuntimeError(f"Staged command disappeared before publish: {command_id}")
             return attach_command_message_i18n(latest)
         return command
+
+    async def recover_next_deferred_command(self) -> bool:
+        command = None
+        try:
+            command = await self.repo.find_next_ready()
+            if command is None:
+                command = await self.repo.find_next_expired_staged(
+                    (datetime.now() - STAGED_COMMAND_LEASE).isoformat()
+                )
+                if command is None:
+                    return False
+                command = await self.mark_staged_command_ready(command.id)
+            await self.publish_staged_command(command.id, source=ActionSource.api)
+        except Exception:
+            logger.exception(
+                "Failed to recover deferred command%s",
+                f" {command.id}" if command else "",
+            )
+            return False
+        return True
 
     async def discard_staged_command(self, command_id: str) -> bool:
         return await self.repo.delete_staged_command(command_id)
@@ -273,8 +307,9 @@ class CommandService:
         source: ActionSource,
         *,
         create_action: bool = True,
+        deduplicate: bool = True,
     ) -> CommandRecord:
-        if not command.uniq_key:
+        if not command.uniq_key or not deduplicate:
             attach_command_message_i18n(command)
             await self.repo.insert(command)
             if create_action:

--- a/backend/app/services/application/commands/service.py
+++ b/backend/app/services/application/commands/service.py
@@ -28,7 +28,7 @@ from app.services.application.commands.setup import create_command_handler_regis
 from app.schemas.constants.event_types import EventTypes
 
 logger = logging.getLogger("app.services.command")
-STAGED_COMMAND_LEASE = timedelta(minutes=5)
+STAGED_COMMAND_MAX_AGE = timedelta(hours=24)
 
 class CommandConflictException(Exception):
     pass
@@ -49,6 +49,11 @@ class CommandService:
         await self.reset_running_commands()
 
     async def reset_running_commands(self) -> None:
+        expired_count = await self.repo.delete_expired_staged_commands(
+            (datetime.now() - STAGED_COMMAND_MAX_AGE).isoformat()
+        )
+        if expired_count:
+            logger.info("Removed %d expired staged commands", expired_count)
         running_commands = await self.repo.find_running()
         for command in running_commands:
             command.status = CommandStatus.FAILED
@@ -130,6 +135,15 @@ class CommandService:
             command.status = CommandStatus.READY
         return attach_command_message_i18n(command)
 
+    async def reserve_ready_command(self, command_id: str) -> CommandRecord:
+        reserved = await self.repo.reserve_ready_command(command_id)
+        command = await self.repo.find_by_id(command_id)
+        if not command:
+            raise RuntimeError(f"Ready command disappeared before reserve: {command_id}")
+        if reserved:
+            command.status = CommandStatus.STAGED
+        return attach_command_message_i18n(command)
+
     async def publish_staged_command(
         self,
         command_id: str,
@@ -157,12 +171,7 @@ class CommandService:
         try:
             command = await self.repo.find_next_ready()
             if command is None:
-                command = await self.repo.find_next_expired_staged(
-                    (datetime.now() - STAGED_COMMAND_LEASE).isoformat()
-                )
-                if command is None:
-                    return False
-                command = await self.mark_staged_command_ready(command.id)
+                return False
             await self.publish_staged_command(command.id, source=ActionSource.api)
         except Exception:
             logger.exception(

--- a/backend/app/services/application/workflows/media_external_mapping/service.py
+++ b/backend/app/services/application/workflows/media_external_mapping/service.py
@@ -61,10 +61,10 @@ class MediaExternalMappingApplicationService:
                 douban_id=None,
                 episode_count_override=episode_count_override,
             )
-            command = await profile_refresh_command_service.publish(command)
         except Exception:
             await profile_refresh_command_service.discard(command)
             raise
+        command = await profile_refresh_command_service.publish(command)
         return MediaExternalMappingAttachCommandResult(
             media_id=result.canonical_media_id,
             command=command,

--- a/backend/app/services/application/workflows/media_external_mapping/service.py
+++ b/backend/app/services/application/workflows/media_external_mapping/service.py
@@ -40,6 +40,11 @@ class MediaExternalMappingApplicationService:
             episode_count_override=episode_count_override,
         )
         try:
+            if result.canonical_media_id.media_type == MediaType.tv and target_season_number:
+                await media_service.refresh_profile(
+                    result.canonical_media_id,
+                    season_number=target_season_number,
+                )
             command = await profile_refresh_command_service.enqueue(
                 result.canonical_media_id,
                 season_number=target_season_number,

--- a/backend/app/services/application/workflows/media_external_mapping/service.py
+++ b/backend/app/services/application/workflows/media_external_mapping/service.py
@@ -69,6 +69,7 @@ class MediaExternalMappingApplicationService:
                 finalize_mapping,
             )
         except Exception:
+            self.mapping_service.rollback_tmdb_mapping_attach(result)
             await profile_refresh_command_service.discard(command)
             raise
         try:

--- a/backend/app/services/application/workflows/media_external_mapping/service.py
+++ b/backend/app/services/application/workflows/media_external_mapping/service.py
@@ -1,3 +1,5 @@
+import logging
+
 from pydantic import BaseModel
 
 from app.schemas.domain.command import CommandInitiator, CommandRecord
@@ -7,6 +9,8 @@ from app.services.application.commands.target_labels import format_media_target_
 from app.services.application.workflows.profile_refresh.service import profile_refresh_command_service
 from app.services.domain.media import media_service
 from app.services.domain.media.mapping import MediaExternalMappingService, media_external_mapping_service
+
+logger = logging.getLogger("app.services.media_external_mapping")
 
 
 class MediaExternalMappingAttachCommandResult(BaseModel):
@@ -55,6 +59,10 @@ class MediaExternalMappingApplicationService:
 
         try:
             self.mapping_service.finalize_tmdb_mapping_attach(result)
+        except Exception:
+            await profile_refresh_command_service.discard(command)
+            raise
+        try:
             await media_service.apply_source_mapping_snapshot(
                 result.canonical_media_id,
                 season_number=target_season_number,
@@ -62,8 +70,10 @@ class MediaExternalMappingApplicationService:
                 episode_count_override=episode_count_override,
             )
         except Exception:
-            await profile_refresh_command_service.discard(command)
-            raise
+            logger.exception(
+                "Mapping snapshot failed; deferred refresh retained: command=%s",
+                command.id,
+            )
         command = await profile_refresh_command_service.publish(command)
         return MediaExternalMappingAttachCommandResult(
             media_id=result.canonical_media_id,

--- a/backend/app/services/application/workflows/media_external_mapping/service.py
+++ b/backend/app/services/application/workflows/media_external_mapping/service.py
@@ -58,7 +58,16 @@ class MediaExternalMappingApplicationService:
             raise
 
         try:
-            self.mapping_service.finalize_tmdb_mapping_attach(result)
+            def finalize_mapping(session) -> None:
+                self.mapping_service.finalize_tmdb_mapping_attach(
+                    result,
+                    session=session,
+                )
+
+            command = await profile_refresh_command_service.finalize_replacement(
+                command,
+                finalize_mapping,
+            )
         except Exception:
             await profile_refresh_command_service.discard(command)
             raise

--- a/backend/app/services/application/workflows/media_external_mapping/service.py
+++ b/backend/app/services/application/workflows/media_external_mapping/service.py
@@ -3,6 +3,7 @@ from pydantic import BaseModel
 from app.schemas.domain.command import CommandInitiator, CommandRecord
 from app.schemas.domain.media_types import MediaType
 from app.schemas.media_id import MediaID
+from app.services.application.commands.target_labels import format_media_target_label
 from app.services.application.workflows.profile_refresh.service import profile_refresh_command_service
 from app.services.domain.media import media_service
 from app.services.domain.media.mapping import MediaExternalMappingService, media_external_mapping_service
@@ -40,16 +41,12 @@ class MediaExternalMappingApplicationService:
             episode_count_override=episode_count_override,
         )
         try:
-            if result.canonical_media_id.media_type == MediaType.tv and target_season_number:
-                await media_service.refresh_profile(
-                    result.canonical_media_id,
-                    season_number=target_season_number,
-                )
             command = await profile_refresh_command_service.enqueue(
                 result.canonical_media_id,
                 season_number=target_season_number,
                 initiator=CommandInitiator.SYSTEM,
                 force_requeue=True,
+                target_label=format_media_target_label(media),
             )
         except Exception:
             self.mapping_service.rollback_tmdb_mapping_attach(result)

--- a/backend/app/services/application/workflows/media_external_mapping/service.py
+++ b/backend/app/services/application/workflows/media_external_mapping/service.py
@@ -47,18 +47,24 @@ class MediaExternalMappingApplicationService:
                 initiator=CommandInitiator.SYSTEM,
                 force_requeue=True,
                 target_label=format_media_target_label(media),
+                defer_publish=True,
             )
         except Exception:
             self.mapping_service.rollback_tmdb_mapping_attach(result)
             raise
 
-        self.mapping_service.finalize_tmdb_mapping_attach(result)
-        await media_service.apply_source_mapping_snapshot(
-            result.canonical_media_id,
-            season_number=target_season_number,
-            douban_id=None,
-            episode_count_override=episode_count_override,
-        )
+        try:
+            self.mapping_service.finalize_tmdb_mapping_attach(result)
+            await media_service.apply_source_mapping_snapshot(
+                result.canonical_media_id,
+                season_number=target_season_number,
+                douban_id=None,
+                episode_count_override=episode_count_override,
+            )
+            command = await profile_refresh_command_service.publish(command)
+        except Exception:
+            await profile_refresh_command_service.discard(command)
+            raise
         return MediaExternalMappingAttachCommandResult(
             media_id=result.canonical_media_id,
             command=command,

--- a/backend/app/services/application/workflows/media_external_mapping/service.py
+++ b/backend/app/services/application/workflows/media_external_mapping/service.py
@@ -1,4 +1,5 @@
 import logging
+from functools import partial
 
 from pydantic import BaseModel
 
@@ -8,7 +9,11 @@ from app.schemas.media_id import MediaID
 from app.services.application.commands.target_labels import format_media_target_label
 from app.services.application.workflows.profile_refresh.service import profile_refresh_command_service
 from app.services.domain.media import media_service
-from app.services.domain.media.mapping import MediaExternalMappingService, media_external_mapping_service
+from app.services.domain.media.mapping import (
+    MediaExternalMappingService,
+    TMDBMappingAttachResult,
+    media_external_mapping_service,
+)
 
 logger = logging.getLogger("app.services.media_external_mapping")
 
@@ -25,6 +30,12 @@ class MediaExternalMappingApplicationService:
         mapping_service: MediaExternalMappingService | None = None,
     ) -> None:
         self.mapping_service = mapping_service or media_external_mapping_service
+
+    def _finalize_mapping(self, result: TMDBMappingAttachResult, session) -> None:
+        self.mapping_service.finalize_tmdb_mapping_attach(
+            result,
+            session=session,
+        )
 
     async def attach_tmdb_mapping(
         self,
@@ -58,15 +69,9 @@ class MediaExternalMappingApplicationService:
             raise
 
         try:
-            def finalize_mapping(session) -> None:
-                self.mapping_service.finalize_tmdb_mapping_attach(
-                    result,
-                    session=session,
-                )
-
             command = await profile_refresh_command_service.finalize_replacement(
                 command,
-                finalize_mapping,
+                partial(self._finalize_mapping, result),
             )
         except Exception:
             self.mapping_service.rollback_tmdb_mapping_attach(result)

--- a/backend/app/services/application/workflows/profile_refresh/service.py
+++ b/backend/app/services/application/workflows/profile_refresh/service.py
@@ -62,6 +62,14 @@ class ProfileRefreshCommandService:
                 return reserved
             existing = reserved
         if existing and existing.status.value == "queued":
+            if defer_publish:
+                return await create_command(
+                    CommandCreateRequest(
+                        type=CommandType.PROFILE_REFRESH,
+                        initiator=initiator,
+                        payload=ProfileRefreshCommandRequestPayload(target=target, target_label=target_label),
+                    )
+                )
             try:
                 await command_service.cancel_command(existing.id)
             except DownloadException:
@@ -115,6 +123,12 @@ class ProfileRefreshCommandService:
         except Exception:
             logger.exception("Deferred profile refresh will be recovered: command=%s", command.id)
             return await command_service.get_command(command.id) or command
+
+    async def finalize_replacement(self, command: CommandRecord, before_ready) -> CommandRecord:
+        return await command_service.finalize_staged_replacement(
+            command.id,
+            before_ready,
+        )
 
     async def discard(self, command: CommandRecord | None) -> None:
         if command and command.status == CommandStatus.STAGED:

--- a/backend/app/services/application/workflows/profile_refresh/service.py
+++ b/backend/app/services/application/workflows/profile_refresh/service.py
@@ -1,3 +1,5 @@
+import logging
+
 from app.schemas.domain.media_types import MediaType
 from app.schemas.exception import DownloadException
 from app.schemas.exception.exceptions import InvalidRequestException
@@ -6,6 +8,8 @@ from app.schemas.domain.action import ActionSource
 from app.schemas.domain.command import CommandCreateRequest, CommandInitiator, CommandRecord, CommandStatus, CommandType, ProfileRefreshCommandRequestPayload
 from app.schemas.domain.media import MediaTarget
 from app.services.application.commands.service import command_service
+
+logger = logging.getLogger("app.services.profile_refresh_command")
 
 
 class ProfileRefreshCommandService:
@@ -83,9 +87,18 @@ class ProfileRefreshCommandService:
         )
 
     async def publish(self, command: CommandRecord) -> CommandRecord:
-        if command.status != CommandStatus.STAGED:
+        try:
+            if command.status == CommandStatus.STAGED:
+                command = await command_service.mark_staged_command_ready(command.id)
+            if command.status == CommandStatus.READY:
+                command = await command_service.publish_staged_command(
+                    command.id,
+                    source=ActionSource.api,
+                )
             return command
-        return await command_service.publish_staged_command(command.id, source=ActionSource.api)
+        except Exception:
+            logger.exception("Deferred profile refresh will be recovered: command=%s", command.id)
+            return await command_service.get_command(command.id) or command
 
     async def discard(self, command: CommandRecord | None) -> None:
         if command and command.status == CommandStatus.STAGED:

--- a/backend/app/services/application/workflows/profile_refresh/service.py
+++ b/backend/app/services/application/workflows/profile_refresh/service.py
@@ -56,6 +56,11 @@ class ProfileRefreshCommandService:
             )
 
         existing = await command_service.find_active_command_by_uniq_key(self._uniq_key(media_id, season_number))
+        if defer_publish and existing and existing.status == CommandStatus.READY:
+            reserved = await command_service.reserve_ready_command(existing.id)
+            if reserved.status == CommandStatus.STAGED:
+                return reserved
+            existing = reserved
         if existing and existing.status.value == "queued":
             try:
                 await command_service.cancel_command(existing.id)
@@ -63,6 +68,17 @@ class ProfileRefreshCommandService:
                 existing = await command_service.find_active_command_by_uniq_key(self._uniq_key(media_id, season_number))
 
         if existing and existing.status.value == "running":
+            followup_uniq_key = self._followup_uniq_key(media_id, season_number)
+            if defer_publish:
+                existing_followup = await command_service.find_active_command_by_uniq_key(
+                    followup_uniq_key
+                )
+                if existing_followup and existing_followup.status == CommandStatus.READY:
+                    reserved = await command_service.reserve_ready_command(
+                        existing_followup.id
+                    )
+                    if reserved.status == CommandStatus.STAGED:
+                        return reserved
             create_with_uniq_key = (
                 command_service.create_staged_command_with_uniq_key
                 if defer_publish
@@ -74,7 +90,7 @@ class ProfileRefreshCommandService:
                     initiator=initiator,
                     payload=ProfileRefreshCommandRequestPayload(target=target, target_label=target_label),
                 ),
-                uniq_key=self._followup_uniq_key(media_id, season_number),
+                uniq_key=followup_uniq_key,
                 source=ActionSource.api,
             )
 

--- a/backend/app/services/application/workflows/profile_refresh/service.py
+++ b/backend/app/services/application/workflows/profile_refresh/service.py
@@ -33,6 +33,7 @@ class ProfileRefreshCommandService:
         initiator: CommandInitiator = CommandInitiator.SYSTEM,
         *,
         force_requeue: bool = False,
+        target_label: str | None = None,
     ) -> CommandRecord | None:
         target = self._target(media_id, season_number)
         if not force_requeue:
@@ -40,7 +41,7 @@ class ProfileRefreshCommandService:
                 CommandCreateRequest(
                     type=CommandType.PROFILE_REFRESH,
                     initiator=initiator,
-                    payload=ProfileRefreshCommandRequestPayload(target=target),
+                    payload=ProfileRefreshCommandRequestPayload(target=target, target_label=target_label),
                 )
             )
 
@@ -56,7 +57,7 @@ class ProfileRefreshCommandService:
                 CommandCreateRequest(
                     type=CommandType.PROFILE_REFRESH,
                     initiator=initiator,
-                    payload=ProfileRefreshCommandRequestPayload(target=target),
+                    payload=ProfileRefreshCommandRequestPayload(target=target, target_label=target_label),
                 ),
                 uniq_key=self._followup_uniq_key(media_id, season_number),
                 source=ActionSource.api,
@@ -66,7 +67,7 @@ class ProfileRefreshCommandService:
             CommandCreateRequest(
                 type=CommandType.PROFILE_REFRESH,
                 initiator=initiator,
-                payload=ProfileRefreshCommandRequestPayload(target=target),
+                payload=ProfileRefreshCommandRequestPayload(target=target, target_label=target_label),
             )
         )
 

--- a/backend/app/services/application/workflows/profile_refresh/service.py
+++ b/backend/app/services/application/workflows/profile_refresh/service.py
@@ -3,7 +3,7 @@ from app.schemas.exception import DownloadException
 from app.schemas.exception.exceptions import InvalidRequestException
 from app.schemas.media_id import MediaID
 from app.schemas.domain.action import ActionSource
-from app.schemas.domain.command import CommandCreateRequest, CommandInitiator, CommandRecord, CommandType, ProfileRefreshCommandRequestPayload
+from app.schemas.domain.command import CommandCreateRequest, CommandInitiator, CommandRecord, CommandStatus, CommandType, ProfileRefreshCommandRequestPayload
 from app.schemas.domain.media import MediaTarget
 from app.services.application.commands.service import command_service
 
@@ -34,10 +34,16 @@ class ProfileRefreshCommandService:
         *,
         force_requeue: bool = False,
         target_label: str | None = None,
+        defer_publish: bool = False,
     ) -> CommandRecord | None:
         target = self._target(media_id, season_number)
+        create_command = (
+            command_service.create_staged_command
+            if defer_publish
+            else command_service.create_command
+        )
         if not force_requeue:
-            return await command_service.create_command(
+            return await create_command(
                 CommandCreateRequest(
                     type=CommandType.PROFILE_REFRESH,
                     initiator=initiator,
@@ -53,7 +59,12 @@ class ProfileRefreshCommandService:
                 existing = await command_service.find_active_command_by_uniq_key(self._uniq_key(media_id, season_number))
 
         if existing and existing.status.value == "running":
-            return await command_service.create_command_with_uniq_key(
+            create_with_uniq_key = (
+                command_service.create_staged_command_with_uniq_key
+                if defer_publish
+                else command_service.create_command_with_uniq_key
+            )
+            return await create_with_uniq_key(
                 CommandCreateRequest(
                     type=CommandType.PROFILE_REFRESH,
                     initiator=initiator,
@@ -63,13 +74,22 @@ class ProfileRefreshCommandService:
                 source=ActionSource.api,
             )
 
-        return await command_service.create_command(
+        return await create_command(
             CommandCreateRequest(
                 type=CommandType.PROFILE_REFRESH,
                 initiator=initiator,
                 payload=ProfileRefreshCommandRequestPayload(target=target, target_label=target_label),
             )
         )
+
+    async def publish(self, command: CommandRecord) -> CommandRecord:
+        if command.status != CommandStatus.STAGED:
+            return command
+        return await command_service.publish_staged_command(command.id, source=ActionSource.api)
+
+    async def discard(self, command: CommandRecord | None) -> None:
+        if command and command.status == CommandStatus.STAGED:
+            await command_service.discard_staged_command(command.id)
 
 
 profile_refresh_command_service = ProfileRefreshCommandService()

--- a/backend/app/services/application/workflows/profile_refresh/service.py
+++ b/backend/app/services/application/workflows/profile_refresh/service.py
@@ -57,10 +57,7 @@ class ProfileRefreshCommandService:
 
         existing = await command_service.find_active_command_by_uniq_key(self._uniq_key(media_id, season_number))
         if defer_publish and existing and existing.status == CommandStatus.READY:
-            reserved = await command_service.reserve_ready_command(existing.id)
-            if reserved.status == CommandStatus.STAGED:
-                return reserved
-            existing = reserved
+            return existing
         if existing and existing.status.value == "queued":
             if defer_publish:
                 return await create_command(
@@ -82,11 +79,7 @@ class ProfileRefreshCommandService:
                     followup_uniq_key
                 )
                 if existing_followup and existing_followup.status == CommandStatus.READY:
-                    reserved = await command_service.reserve_ready_command(
-                        existing_followup.id
-                    )
-                    if reserved.status == CommandStatus.STAGED:
-                        return reserved
+                    return existing_followup
             create_with_uniq_key = (
                 command_service.create_staged_command_with_uniq_key
                 if defer_publish

--- a/backend/app/services/audit/action_service.py
+++ b/backend/app/services/audit/action_service.py
@@ -60,6 +60,7 @@ class ActionService:
         started_at: datetime | None = None,
         finished_at: datetime | None = None,
         duration_ms: int | None = None,
+        persist: bool = True,
     ) -> ActionRecord:
         normalized_meta = _normalize_action_meta(meta)
         try:
@@ -111,7 +112,8 @@ class ActionService:
                 duration_ms=duration_ms,
             )
         attach_action_message_i18n(action)
-        self.repo.insert(action)
+        if persist:
+            self.repo.insert(action)
         return action
 
     def _update_action(

--- a/backend/app/services/domain/media/mapping.py
+++ b/backend/app/services/domain/media/mapping.py
@@ -91,16 +91,43 @@ class MediaExternalMappingService:
             source_douban_media_id=MediaID(provider=Provider.douban, media_type=media.media_type, id=media.douban_id) if media.douban_id else None,
         )
 
-    def finalize_tmdb_mapping_attach(self, result: TMDBMappingAttachResult) -> None:
+    def finalize_tmdb_mapping_attach(self, result: TMDBMappingAttachResult, *, session=None) -> None:
         source_media_id = result.source_media_id
         if source_media_id != result.canonical_media_id:
-            self.identity_repo.merge_media_id(source_media_id, result.canonical_media_id)
+            if session is None:
+                self.identity_repo.merge_media_id(source_media_id, result.canonical_media_id)
+            else:
+                self.identity_repo.merge_media_id(
+                    source_media_id,
+                    result.canonical_media_id,
+                    session=session,
+                )
 
         previous_mapping = result.previous_mapping
         if previous_mapping and previous_mapping.media_id != result.canonical_media_id:
             if previous_mapping.media_id != source_media_id:
-                self.identity_repo.merge_media_id(previous_mapping.media_id, result.canonical_media_id)
-            self.mapping_repo.remove(previous_mapping.media_id, previous_mapping.season_number)
+                if session is None:
+                    self.identity_repo.merge_media_id(
+                        previous_mapping.media_id,
+                        result.canonical_media_id,
+                    )
+                else:
+                    self.identity_repo.merge_media_id(
+                        previous_mapping.media_id,
+                        result.canonical_media_id,
+                        session=session,
+                    )
+            if session is None:
+                self.mapping_repo.remove(
+                    previous_mapping.media_id,
+                    previous_mapping.season_number,
+                )
+            else:
+                self.mapping_repo.remove(
+                    previous_mapping.media_id,
+                    previous_mapping.season_number,
+                    session=session,
+                )
 
     def rollback_tmdb_mapping_attach(self, result: TMDBMappingAttachResult) -> None:
         self.mapping_repo.remove(result.canonical_media_id, result.season_number)

--- a/backend/app/services/domain/media/mapping.py
+++ b/backend/app/services/domain/media/mapping.py
@@ -20,6 +20,7 @@ class TMDBMappingAttachResult(BaseModel):
     source_media_id: MediaID
     season_number: int | None = None
     previous_mapping: MediaExternalMappingRecord | None = None
+    previous_canonical_mapping: MediaExternalMappingRecord | None = None
     source_douban_media_id: MediaID | None = None
 
 
@@ -75,6 +76,14 @@ class MediaExternalMappingService:
             )
         )
         canonical_media_id = MediaID(provider=Provider.tmdb, media_type=media.media_type, id=str(tmdb_id))
+        previous_canonical_mapping = (
+            self.mapping_repo.find_by_media_id_and_season(
+                canonical_media_id,
+                target_season_number,
+            )
+            if media.media_type == MediaType.tv
+            else self.mapping_repo.find_by_media_id(canonical_media_id)
+        )
         self.mapping_repo.upsert(
             media_id=canonical_media_id,
             tmdb_id=tmdb_id,
@@ -88,6 +97,7 @@ class MediaExternalMappingService:
             source_media_id=media.media_id,
             season_number=target_season_number,
             previous_mapping=previous_mapping,
+            previous_canonical_mapping=previous_canonical_mapping,
             source_douban_media_id=MediaID(provider=Provider.douban, media_type=media.media_type, id=media.douban_id) if media.douban_id else None,
         )
 
@@ -131,8 +141,18 @@ class MediaExternalMappingService:
 
     def rollback_tmdb_mapping_attach(self, result: TMDBMappingAttachResult) -> None:
         self.mapping_repo.remove(result.canonical_media_id, result.season_number)
+        previous_canonical_mapping = result.previous_canonical_mapping
+        if previous_canonical_mapping:
+            self.mapping_repo.upsert(
+                media_id=previous_canonical_mapping.media_id,
+                tmdb_id=previous_canonical_mapping.tmdb_id,
+                imdb_id=previous_canonical_mapping.imdb_id,
+                douban_id=previous_canonical_mapping.douban_id,
+                season_number=previous_canonical_mapping.season_number,
+                episode_count_override=previous_canonical_mapping.episode_count_override,
+            )
         previous_mapping = result.previous_mapping
-        if previous_mapping:
+        if previous_mapping and previous_mapping.media_id != result.canonical_media_id:
             self.mapping_repo.upsert(
                 media_id=previous_mapping.media_id,
                 tmdb_id=previous_mapping.tmdb_id,
@@ -141,6 +161,8 @@ class MediaExternalMappingService:
                 season_number=previous_mapping.season_number,
                 episode_count_override=previous_mapping.episode_count_override,
             )
+            return
+        if previous_canonical_mapping:
             return
         if result.source_douban_media_id:
             self.mapping_repo.remove(result.source_douban_media_id, result.season_number)

--- a/backend/app/services/domain/media/profile/service.py
+++ b/backend/app/services/domain/media/profile/service.py
@@ -119,17 +119,12 @@ class MediaProfileService:
         profile = await self.profile_repo.find_by_media_id(media_id)
         if not profile or not profile.detail_ready:
             return
-        scope = await self.scope_repo.find_by_media_id_and_season(media_id, season_number)
-        if not scope:
-            return
-        await self.scope_repo.upsert_scope(
-            scope.model_copy(update={
-                "douban_id": douban_id or scope.douban_id,
-                "episode_count_override": episode_count_override
-                if episode_count_override is not None
-                else scope.episode_count_override,
-                "updated_at": time.time(),
-            })
+        await self.scope_repo.update_mapping_snapshot(
+            media_id,
+            season_number,
+            douban_id=douban_id,
+            episode_count_override=episode_count_override,
+            updated_at=time.time(),
         )
 
     def _build_placeholder_profile(

--- a/backend/scripts/check_backend_quality.py
+++ b/backend/scripts/check_backend_quality.py
@@ -50,7 +50,6 @@ MEDIA_REFRESH_ALLOWLIST_REASONS = {
     "app/services/application/views/calendar/service.py": "Sample",
     "app/services/application/commands/handlers/profile.py": "Sample",
     "app/services/application/workflows/danmu/source_resolver.py": "danmu workflow weakly refreshes season-scoped media before checking fetchable platforms",
-    "app/services/application/workflows/media_external_mapping/service.py": "mapping attach refreshes the selected TV season before finalizing the canonical identity merge",
     "app/services/domain/media/profile/service.py": "text profile text",
     "app/services/domain/media/service.py": "text facade",
     "app/services/domain/transfer/service.py": "text，text",

--- a/backend/scripts/check_backend_quality.py
+++ b/backend/scripts/check_backend_quality.py
@@ -50,6 +50,7 @@ MEDIA_REFRESH_ALLOWLIST_REASONS = {
     "app/services/application/views/calendar/service.py": "Sample",
     "app/services/application/commands/handlers/profile.py": "Sample",
     "app/services/application/workflows/danmu/source_resolver.py": "danmu workflow weakly refreshes season-scoped media before checking fetchable platforms",
+    "app/services/application/workflows/media_external_mapping/service.py": "mapping attach refreshes the selected TV season before finalizing the canonical identity merge",
     "app/services/domain/media/profile/service.py": "text profile text",
     "app/services/domain/media/service.py": "text facade",
     "app/services/domain/transfer/service.py": "text，text",

--- a/backend/tests/test_command_service_dedup.py
+++ b/backend/tests/test_command_service_dedup.py
@@ -417,6 +417,47 @@ async def test_command_repository_season_filter_does_not_include_unscoped_media_
 
 
 @pytest.mark.asyncio
+async def test_command_repository_does_not_offer_staged_command_to_worker():
+    media_id = MediaID.parse("tmdb:tv:1")
+    payload = ProfileRefreshCommandRecordPayload(
+        target=MediaTarget(media_id=media_id, season_number=1),
+    ).model_dump(mode="json")
+    with SessionLocal() as session:
+        session.add(
+            CommandORM(
+                id="cmd-staged-profile-refresh",
+                type=CommandType.PROFILE_REFRESH.value,
+                status=CommandStatus.STAGED.value,
+                payload_json=payload,
+                initiator=CommandInitiator.SYSTEM.value,
+                media_id=str(media_id),
+                target_season_number=1,
+                uniq_key="command:profile.refresh:tmdb:tv:1:season=1",
+                target_type=CommandTargetType.MEDIA.value,
+                target_id=str(media_id),
+                created_at=datetime.now().isoformat(),
+            )
+        )
+        session.commit()
+
+    try:
+        next_command = await CommandRepository().find_next_queued()
+        active = await CommandRepository().find_active_by_uniq_key(
+            "command:profile.refresh:tmdb:tv:1:season=1"
+        )
+    finally:
+        with SessionLocal() as session:
+            session.execute(
+                delete(CommandORM).where(CommandORM.id == "cmd-staged-profile-refresh")
+            )
+            session.commit()
+
+    assert next_command is None
+    assert active is not None
+    assert active.status == CommandStatus.STAGED
+
+
+@pytest.mark.asyncio
 async def test_command_repository_preserves_nested_error_params():
     media_id = MediaID.parse("tmdb:tv:1")
     payload = TaskCreateCommandRecordPayload(

--- a/backend/tests/test_command_service_dedup.py
+++ b/backend/tests/test_command_service_dedup.py
@@ -595,8 +595,7 @@ def test_finalize_staged_replacement_cancels_queued_and_marks_ready_atomically()
         )
 
     try:
-        with SessionLocal.begin() as session:
-            CommandRepository._finalize_staged_replacement(session, ids[1])
+        CommandRepository().finalize_staged_replacement(ids[1], lambda _session: None)
         with SessionLocal() as session:
             statuses = {
                 row.id: row.status
@@ -612,6 +611,32 @@ def test_finalize_staged_replacement_cancels_queued_and_marks_ready_atomically()
         ids[0]: CommandStatus.CANCELLED.value,
         ids[1]: CommandStatus.READY.value,
     }
+
+
+@pytest.mark.asyncio
+async def test_finalize_existing_ready_rolls_back_callback_failure():
+    repo = CommandRepository()
+    command = _media_command(
+        "cmd-ready-before-new-mapping",
+        CommandType.PROFILE_REFRESH,
+        season_number=1,
+    )
+    command.status = CommandStatus.READY
+    await repo.insert(command)
+
+    def fail_finalize(_session):
+        raise RuntimeError("identity merge failed")
+
+    try:
+        with pytest.raises(RuntimeError, match="identity merge failed"):
+            repo.finalize_staged_replacement(command.id, fail_finalize)
+        saved = await repo.find_by_id(command.id)
+    finally:
+        with SessionLocal.begin() as session:
+            session.execute(delete(CommandORM).where(CommandORM.id == command.id))
+
+    assert saved is not None
+    assert saved.status == CommandStatus.READY
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_command_service_dedup.py
+++ b/backend/tests/test_command_service_dedup.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 from pydantic import ValidationError
-from sqlalchemy import delete
+from sqlalchemy import delete, select
 
 pytestmark = [pytest.mark.drift, pytest.mark.health]
 
@@ -554,6 +554,64 @@ async def test_publish_staged_command_commits_command_and_action_together(monkey
     assert saved is not None
     assert saved.status == CommandStatus.READY
     assert persisted_action is None
+
+
+def test_finalize_staged_replacement_cancels_queued_and_marks_ready_atomically():
+    uniq_key = "command:profile.refresh:tmdb:tv:1:season=1"
+    payload = ProfileRefreshCommandRecordPayload(
+        target=MediaTarget(media_id=MediaID.parse("tmdb:tv:1"), season_number=1),
+    ).model_dump(mode="json")
+    ids = ["cmd-queued-before-mapping", "cmd-staged-after-mapping"]
+    with SessionLocal.begin() as session:
+        session.add_all(
+            [
+                CommandORM(
+                    id=ids[0],
+                    type=CommandType.PROFILE_REFRESH.value,
+                    status=CommandStatus.QUEUED.value,
+                    payload_json=payload,
+                    initiator=CommandInitiator.SYSTEM.value,
+                    media_id="tmdb:tv:1",
+                    target_season_number=1,
+                    uniq_key=uniq_key,
+                    target_type=CommandTargetType.MEDIA.value,
+                    target_id="tmdb:tv:1",
+                    created_at=datetime.now().isoformat(),
+                ),
+                CommandORM(
+                    id=ids[1],
+                    type=CommandType.PROFILE_REFRESH.value,
+                    status=CommandStatus.STAGED.value,
+                    payload_json=payload,
+                    initiator=CommandInitiator.SYSTEM.value,
+                    media_id="tmdb:tv:1",
+                    target_season_number=1,
+                    uniq_key=uniq_key,
+                    target_type=CommandTargetType.MEDIA.value,
+                    target_id="tmdb:tv:1",
+                    created_at=datetime.now().isoformat(),
+                ),
+            ]
+        )
+
+    try:
+        with SessionLocal.begin() as session:
+            CommandRepository._finalize_staged_replacement(session, ids[1])
+        with SessionLocal() as session:
+            statuses = {
+                row.id: row.status
+                for row in session.execute(
+                    select(CommandORM).where(CommandORM.id.in_(ids))
+                ).scalars()
+            }
+    finally:
+        with SessionLocal.begin() as session:
+            session.execute(delete(CommandORM).where(CommandORM.id.in_(ids)))
+
+    assert statuses == {
+        ids[0]: CommandStatus.CANCELLED.value,
+        ids[1]: CommandStatus.READY.value,
+    }
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_command_service_dedup.py
+++ b/backend/tests/test_command_service_dedup.py
@@ -199,26 +199,21 @@ async def test_staged_submit_does_not_reuse_published_uniq_key(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_recover_expired_staged_command_promotes_and_publishes(monkeypatch):
+async def test_recover_deferred_command_publishes_only_ready(monkeypatch):
     service = CommandService()
-    staged = _command(command_id="cmd-expired-staged", uniq_key=None)
-    staged.status = CommandStatus.STAGED
-    ready = staged.model_copy(update={"status": CommandStatus.READY})
-    queued = staged.model_copy(update={"status": CommandStatus.QUEUED})
-    monkeypatch.setattr(service.repo, "find_next_ready", AsyncMock(return_value=None))
-    find_expired = AsyncMock(return_value=staged)
-    monkeypatch.setattr(service.repo, "find_next_expired_staged", find_expired)
-    mark_ready = AsyncMock(return_value=ready)
-    monkeypatch.setattr(service, "mark_staged_command_ready", mark_ready)
+    ready = _command(command_id="cmd-ready-recovery", uniq_key=None)
+    ready.status = CommandStatus.READY
+    queued = ready.model_copy(update={"status": CommandStatus.QUEUED})
+    find_ready = AsyncMock(return_value=ready)
+    monkeypatch.setattr(service.repo, "find_next_ready", find_ready)
     publish = AsyncMock(return_value=queued)
     monkeypatch.setattr(service, "publish_staged_command", publish)
 
     recovered = await service.recover_next_deferred_command()
 
     assert recovered is True
-    find_expired.assert_awaited_once()
-    mark_ready.assert_awaited_once_with(staged.id)
-    publish.assert_awaited_once_with(staged.id, source=ActionSource.api)
+    find_ready.assert_awaited_once()
+    publish.assert_awaited_once_with(ready.id, source=ActionSource.api)
 
 
 @pytest.mark.asyncio
@@ -562,7 +557,7 @@ async def test_publish_staged_command_commits_command_and_action_together(monkey
 
 
 @pytest.mark.asyncio
-async def test_expired_staged_query_preserves_recent_command():
+async def test_expired_staged_cleanup_preserves_recent_command():
     repo = CommandRepository()
     old_command = _media_command("cmd-staged-old", CommandType.PROFILE_REFRESH, season_number=1)
     old_command.status = CommandStatus.STAGED
@@ -573,7 +568,7 @@ async def test_expired_staged_query_preserves_recent_command():
     await repo.insert(recent_command)
 
     try:
-        expired = await repo.find_next_expired_staged(
+        deleted = await repo.delete_expired_staged_commands(
             (datetime.now() - timedelta(days=1)).isoformat()
         )
         old_saved = await repo.find_by_id(old_command.id)
@@ -586,9 +581,8 @@ async def test_expired_staged_query_preserves_recent_command():
                 )
             )
 
-    assert expired is not None
-    assert expired.id == old_command.id
-    assert old_saved is not None
+    assert deleted == 1
+    assert old_saved is None
     assert recent_saved is not None
     assert recent_saved.status == CommandStatus.STAGED
 

--- a/backend/tests/test_command_service_dedup.py
+++ b/backend/tests/test_command_service_dedup.py
@@ -561,7 +561,11 @@ def test_finalize_staged_replacement_cancels_queued_and_marks_ready_atomically()
     payload = ProfileRefreshCommandRecordPayload(
         target=MediaTarget(media_id=MediaID.parse("tmdb:tv:1"), season_number=1),
     ).model_dump(mode="json")
-    ids = ["cmd-queued-before-mapping", "cmd-staged-after-mapping"]
+    ids = [
+        "cmd-existing-before-mapping",
+        "cmd-ready-before-mapping",
+        "cmd-staged-after-mapping",
+    ]
     with SessionLocal.begin() as session:
         session.add_all(
             [
@@ -581,6 +585,19 @@ def test_finalize_staged_replacement_cancels_queued_and_marks_ready_atomically()
                 CommandORM(
                     id=ids[1],
                     type=CommandType.PROFILE_REFRESH.value,
+                    status=CommandStatus.READY.value,
+                    payload_json=payload,
+                    initiator=CommandInitiator.SYSTEM.value,
+                    media_id="tmdb:tv:1",
+                    target_season_number=1,
+                    uniq_key=uniq_key,
+                    target_type=CommandTargetType.MEDIA.value,
+                    target_id="tmdb:tv:1",
+                    created_at=datetime.now().isoformat(),
+                ),
+                CommandORM(
+                    id=ids[2],
+                    type=CommandType.PROFILE_REFRESH.value,
                     status=CommandStatus.STAGED.value,
                     payload_json=payload,
                     initiator=CommandInitiator.SYSTEM.value,
@@ -593,9 +610,24 @@ def test_finalize_staged_replacement_cancels_queued_and_marks_ready_atomically()
                 ),
             ]
         )
+        ActionRepository.add_to_session(
+            session,
+            ActionRecord(
+                id=ids[0],
+                kind=ActionKind.command,
+                action_name=CommandType.PROFILE_REFRESH.value,
+                status=ActionStatus.queued,
+                actor=ActionActor.system,
+                trigger=ActionTrigger.system,
+                source=ActionSource.api,
+                target_type=ActionTargetType.media,
+                target_id="tmdb:tv:1",
+                correlation_id=ids[0],
+            ),
+        )
 
     try:
-        CommandRepository().finalize_staged_replacement(ids[1], lambda _session: None)
+        CommandRepository().finalize_staged_replacement(ids[2], lambda _session: None)
         with SessionLocal() as session:
             statuses = {
                 row.id: row.status
@@ -603,14 +635,21 @@ def test_finalize_staged_replacement_cancels_queued_and_marks_ready_atomically()
                     select(CommandORM).where(CommandORM.id.in_(ids))
                 ).scalars()
             }
+            cancelled_action = session.get(ActionORM, ids[0])
     finally:
         with SessionLocal.begin() as session:
+            session.execute(delete(ActionORM).where(ActionORM.id == ids[0]))
             session.execute(delete(CommandORM).where(CommandORM.id.in_(ids)))
 
     assert statuses == {
         ids[0]: CommandStatus.CANCELLED.value,
-        ids[1]: CommandStatus.READY.value,
+        ids[1]: CommandStatus.CANCELLED.value,
+        ids[2]: CommandStatus.READY.value,
     }
+    assert cancelled_action is not None
+    assert cancelled_action.status == ActionStatus.cancelled.value
+    assert "cancelled" in cancelled_action.search_text
+    assert "queued" not in cancelled_action.search_text
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_command_service_dedup.py
+++ b/backend/tests/test_command_service_dedup.py
@@ -175,6 +175,53 @@ async def test_submit_command_without_uniq_key_is_enqueued_normally(monkeypatch)
 
 
 @pytest.mark.asyncio
+async def test_staged_submit_does_not_reuse_published_uniq_key(monkeypatch):
+    service = CommandService()
+    incoming = _command(command_id="cmd-staged-owned", uniq_key="command:task.transfer:task-1")
+    incoming.status = CommandStatus.STAGED
+    existing = _command(command_id="cmd-existing", uniq_key=incoming.uniq_key)
+    existing.status = CommandStatus.QUEUED
+    find_mock = AsyncMock(return_value=existing)
+    insert_mock = AsyncMock(return_value=incoming.id)
+    monkeypatch.setattr(service.repo, "find_active_by_uniq_key", find_mock)
+    monkeypatch.setattr(service.repo, "insert", insert_mock)
+
+    result = await service._submit_command(
+        incoming,
+        source=ActionSource.api,
+        create_action=False,
+        deduplicate=False,
+    )
+
+    assert result.id == incoming.id
+    find_mock.assert_not_awaited()
+    insert_mock.assert_awaited_once_with(incoming)
+
+
+@pytest.mark.asyncio
+async def test_recover_expired_staged_command_promotes_and_publishes(monkeypatch):
+    service = CommandService()
+    staged = _command(command_id="cmd-expired-staged", uniq_key=None)
+    staged.status = CommandStatus.STAGED
+    ready = staged.model_copy(update={"status": CommandStatus.READY})
+    queued = staged.model_copy(update={"status": CommandStatus.QUEUED})
+    monkeypatch.setattr(service.repo, "find_next_ready", AsyncMock(return_value=None))
+    find_expired = AsyncMock(return_value=staged)
+    monkeypatch.setattr(service.repo, "find_next_expired_staged", find_expired)
+    mark_ready = AsyncMock(return_value=ready)
+    monkeypatch.setattr(service, "mark_staged_command_ready", mark_ready)
+    publish = AsyncMock(return_value=queued)
+    monkeypatch.setattr(service, "publish_staged_command", publish)
+
+    recovered = await service.recover_next_deferred_command()
+
+    assert recovered is True
+    find_expired.assert_awaited_once()
+    mark_ready.assert_awaited_once_with(staged.id)
+    publish.assert_awaited_once_with(staged.id, source=ActionSource.api)
+
+
+@pytest.mark.asyncio
 async def test_run_next_queued_command_stores_app_exception_as_error_key(monkeypatch):
     service = CommandService()
     command = _command(command_id="cmd-app-error", uniq_key=None)
@@ -455,6 +502,12 @@ async def test_command_repository_does_not_offer_or_dedupe_staged_command():
         active = await CommandRepository().find_active_by_uniq_key(
             "command:profile.refresh:tmdb:tv:1:season=1"
         )
+        public_active = await CommandRepository().find_active_filtered(
+            target_type=CommandTargetType.MEDIA,
+            target_ids=[str(media_id)],
+            target_season_number=1,
+            command_types=[CommandType.PROFILE_REFRESH],
+        )
     finally:
         with SessionLocal() as session:
             session.execute(
@@ -464,13 +517,14 @@ async def test_command_repository_does_not_offer_or_dedupe_staged_command():
 
     assert next_command is None
     assert active is None
+    assert public_active == []
 
 
 @pytest.mark.asyncio
 async def test_publish_staged_command_commits_command_and_action_together(monkeypatch):
     repo = CommandRepository()
     command = _media_command("cmd-atomic-publish", CommandType.PROFILE_REFRESH, season_number=1)
-    command.status = CommandStatus.STAGED
+    command.status = CommandStatus.READY
     command.uniq_key = "command:profile.refresh:tmdb:tv:1:season=1"
     await repo.insert(command)
     queued = command.model_copy(update={"status": CommandStatus.QUEUED})
@@ -503,12 +557,12 @@ async def test_publish_staged_command_commits_command_and_action_together(monkey
             session.execute(delete(CommandORM).where(CommandORM.id == command.id))
 
     assert saved is not None
-    assert saved.status == CommandStatus.STAGED
+    assert saved.status == CommandStatus.READY
     assert persisted_action is None
 
 
 @pytest.mark.asyncio
-async def test_expired_staged_cleanup_preserves_recent_command():
+async def test_expired_staged_query_preserves_recent_command():
     repo = CommandRepository()
     old_command = _media_command("cmd-staged-old", CommandType.PROFILE_REFRESH, season_number=1)
     old_command.status = CommandStatus.STAGED
@@ -519,7 +573,7 @@ async def test_expired_staged_cleanup_preserves_recent_command():
     await repo.insert(recent_command)
 
     try:
-        deleted = await repo.delete_expired_staged_commands(
+        expired = await repo.find_next_expired_staged(
             (datetime.now() - timedelta(days=1)).isoformat()
         )
         old_saved = await repo.find_by_id(old_command.id)
@@ -532,8 +586,9 @@ async def test_expired_staged_cleanup_preserves_recent_command():
                 )
             )
 
-    assert deleted == 1
-    assert old_saved is None
+    assert expired is not None
+    assert expired.id == old_command.id
+    assert old_saved is not None
     assert recent_saved is not None
     assert recent_saved.status == CommandStatus.STAGED
 

--- a/backend/tests/test_command_service_dedup.py
+++ b/backend/tests/test_command_service_dedup.py
@@ -1,6 +1,6 @@
 import os
 import uuid
-from datetime import datetime
+from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, Mock
 
 import pytest
@@ -32,10 +32,20 @@ from app.schemas.domain.media import MediaIdentity, MediaTarget
 from app.schemas.exception import InvalidRequestException
 from app.schemas.media_id import MediaID
 from app.db.repositories.command_repository import CommandRepository
-from app.db.sql.models import CommandORM
+from app.db.repositories.action_repository import ActionRepository
+from app.db.sql.models import ActionORM, CommandORM
 from app.db.sql.session import SessionLocal
 from app.services.audit.event_message_i18n import event_message_key, event_message_params
 from app.services.application.commands.service import CommandService
+from app.schemas.domain.action import (
+    ActionActor,
+    ActionKind,
+    ActionRecord,
+    ActionSource,
+    ActionStatus,
+    ActionTargetType,
+    ActionTrigger,
+)
 
 
 def _command(*, command_id: str, uniq_key: str | None) -> CommandRecord:
@@ -417,7 +427,7 @@ async def test_command_repository_season_filter_does_not_include_unscoped_media_
 
 
 @pytest.mark.asyncio
-async def test_command_repository_does_not_offer_staged_command_to_worker():
+async def test_command_repository_does_not_offer_or_dedupe_staged_command():
     media_id = MediaID.parse("tmdb:tv:1")
     payload = ProfileRefreshCommandRecordPayload(
         target=MediaTarget(media_id=media_id, season_number=1),
@@ -453,8 +463,79 @@ async def test_command_repository_does_not_offer_staged_command_to_worker():
             session.commit()
 
     assert next_command is None
-    assert active is not None
-    assert active.status == CommandStatus.STAGED
+    assert active is None
+
+
+@pytest.mark.asyncio
+async def test_publish_staged_command_commits_command_and_action_together(monkeypatch):
+    repo = CommandRepository()
+    command = _media_command("cmd-atomic-publish", CommandType.PROFILE_REFRESH, season_number=1)
+    command.status = CommandStatus.STAGED
+    command.uniq_key = "command:profile.refresh:tmdb:tv:1:season=1"
+    await repo.insert(command)
+    queued = command.model_copy(update={"status": CommandStatus.QUEUED})
+    action = ActionRecord(
+        id=command.id,
+        kind=ActionKind.command,
+        action_name=CommandType.PROFILE_REFRESH.value,
+        status=ActionStatus.queued,
+        actor=ActionActor.system,
+        trigger=ActionTrigger.system,
+        source=ActionSource.api,
+        target_type=ActionTargetType.media,
+        target_id=str(command.media_id),
+        correlation_id=command.id,
+    )
+
+    def fail_action_insert(_session, _action):
+        raise RuntimeError("action insert failed")
+
+    monkeypatch.setattr(ActionRepository, "add_to_session", fail_action_insert)
+    try:
+        with pytest.raises(RuntimeError, match="action insert failed"):
+            await repo.publish_staged_command(queued, action)
+        saved = await repo.find_by_id(command.id)
+        with SessionLocal() as session:
+            persisted_action = session.get(ActionORM, command.id)
+    finally:
+        with SessionLocal.begin() as session:
+            session.execute(delete(ActionORM).where(ActionORM.id == command.id))
+            session.execute(delete(CommandORM).where(CommandORM.id == command.id))
+
+    assert saved is not None
+    assert saved.status == CommandStatus.STAGED
+    assert persisted_action is None
+
+
+@pytest.mark.asyncio
+async def test_expired_staged_cleanup_preserves_recent_command():
+    repo = CommandRepository()
+    old_command = _media_command("cmd-staged-old", CommandType.PROFILE_REFRESH, season_number=1)
+    old_command.status = CommandStatus.STAGED
+    old_command.created_at = datetime.now() - timedelta(days=2)
+    recent_command = _media_command("cmd-staged-recent", CommandType.PROFILE_REFRESH, season_number=1)
+    recent_command.status = CommandStatus.STAGED
+    await repo.insert(old_command)
+    await repo.insert(recent_command)
+
+    try:
+        deleted = await repo.delete_expired_staged_commands(
+            (datetime.now() - timedelta(days=1)).isoformat()
+        )
+        old_saved = await repo.find_by_id(old_command.id)
+        recent_saved = await repo.find_by_id(recent_command.id)
+    finally:
+        with SessionLocal.begin() as session:
+            session.execute(
+                delete(CommandORM).where(
+                    CommandORM.id.in_([old_command.id, recent_command.id])
+                )
+            )
+
+    assert deleted == 1
+    assert old_saved is None
+    assert recent_saved is not None
+    assert recent_saved.status == CommandStatus.STAGED
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_command_service_dedup.py
+++ b/backend/tests/test_command_service_dedup.py
@@ -226,7 +226,9 @@ async def test_run_next_queued_command_stores_app_exception_as_error_key(monkeyp
         async def execute(self, _command):
             raise InvalidRequestException("backendErrors.seasonRequired")
 
-    monkeypatch.setattr(service.repo, "find_next_queued", AsyncMock(return_value=command))
+    command.status = CommandStatus.RUNNING
+    claim_next = AsyncMock(return_value=command)
+    monkeypatch.setattr(service.repo, "claim_next_queued", claim_next)
     monkeypatch.setattr(service.repo, "find_by_id", AsyncMock(return_value=None))
     monkeypatch.setattr(service.repo, "update", AsyncMock(side_effect=lambda item, _cond: updated.append(item.model_copy(deep=True)) or True))
     monkeypatch.setattr(service, "_get_registry", lambda: FakeRegistry())
@@ -237,6 +239,7 @@ async def test_run_next_queued_command_stores_app_exception_as_error_key(monkeyp
     result = await service.run_next_queued_command()
 
     assert result is True
+    claim_next.assert_awaited_once()
     failed = updated[-1]
     assert failed.status == CommandStatus.FAILED
     assert failed.error is None
@@ -676,6 +679,49 @@ async def test_finalize_existing_ready_rolls_back_callback_failure():
 
     assert saved is not None
     assert saved.status == CommandStatus.READY
+
+
+@pytest.mark.asyncio
+async def test_atomic_claim_prevents_mapping_finalizer_from_cancelling_worker_command():
+    repo = CommandRepository()
+    uniq_key = "command:profile.refresh:tmdb:tv:1:season=1"
+    queued = _media_command(
+        "cmd-worker-claim",
+        CommandType.PROFILE_REFRESH,
+        season_number=1,
+    )
+    queued.uniq_key = uniq_key
+    queued.created_at = datetime.now() - timedelta(seconds=1)
+    staged = _media_command(
+        "cmd-mapping-replacement",
+        CommandType.PROFILE_REFRESH,
+        season_number=1,
+    )
+    staged.status = CommandStatus.STAGED
+    staged.uniq_key = uniq_key
+    await repo.insert(queued)
+    await repo.insert(staged)
+
+    try:
+        claimed = await repo.claim_next_queued(datetime.now().isoformat())
+        repo.finalize_staged_replacement(staged.id, lambda _session: None)
+        claimed_saved = await repo.find_by_id(queued.id)
+        replacement_saved = await repo.find_by_id(staged.id)
+    finally:
+        with SessionLocal.begin() as session:
+            session.execute(
+                delete(CommandORM).where(
+                    CommandORM.id.in_([queued.id, staged.id])
+                )
+            )
+
+    assert claimed is not None
+    assert claimed.id == queued.id
+    assert claimed.status == CommandStatus.RUNNING
+    assert claimed_saved is not None
+    assert claimed_saved.status == CommandStatus.RUNNING
+    assert replacement_saved is not None
+    assert replacement_saved.status == CommandStatus.READY
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_external_mapping_tmdb.py
+++ b/backend/tests/test_external_mapping_tmdb.py
@@ -106,6 +106,19 @@ def _command(media_id: MediaID, command_id: str = "cmd-1") -> CommandRecord:
     )
 
 
+def _mock_atomic_command_finalization(monkeypatch) -> AsyncMock:
+    async def finalize(command, before_ready):
+        before_ready(Mock())
+        return command.model_copy(update={"status": CommandStatus.READY})
+
+    finalize_mock = AsyncMock(side_effect=finalize)
+    monkeypatch.setattr(
+        "app.services.application.workflows.media_external_mapping.service.profile_refresh_command_service.finalize_replacement",
+        finalize_mock,
+    )
+    return finalize_mock
+
+
 def _media(mid: MediaID, *, imdb_id="tt0499549", douban_id: str | None = None, season_number: int | None = None) -> MediaSimpleInfo:
     return MediaSimpleInfo(
         media_id=mid,
@@ -359,6 +372,7 @@ async def test_attach_tmdb_mapping_keeps_existing_imdb_id_when_tmdb_external_ids
 
 @pytest.mark.asyncio
 async def test_attach_tmdb_mapping_uses_profile_refresh_command_service_force_requeue(monkeypatch):
+    _mock_atomic_command_finalization(monkeypatch)
     mid = MediaID.parse("tmdb:movie:19995")
     canonical_mid = MediaID.parse("tmdb:movie:12345")
     enqueue_mock = AsyncMock(side_effect=lambda media_id, **_: _command(media_id, "cmd-force-requeue"))
@@ -387,6 +401,7 @@ async def test_attach_tmdb_mapping_uses_profile_refresh_command_service_force_re
 
 @pytest.mark.asyncio
 async def test_attach_tmdb_mapping_application_keeps_requested_tv_season(monkeypatch):
+    _mock_atomic_command_finalization(monkeypatch)
     mid = MediaID.parse("tmdb:tv:19995")
     canonical_mid = MediaID.parse("tmdb:tv:12345")
     enqueue_mock = AsyncMock(side_effect=lambda media_id, **_: _command(media_id, "cmd-season"))
@@ -432,6 +447,7 @@ async def test_attach_tmdb_mapping_application_keeps_requested_tv_season(monkeyp
 
 @pytest.mark.asyncio
 async def test_attach_tmdb_mapping_publishes_refresh_only_after_identity_finalization(monkeypatch):
+    _mock_atomic_command_finalization(monkeypatch)
     mid = MediaID.parse("tmdb:tv:19994")
     canonical_mid = MediaID.parse("tmdb:tv:12344")
     staged = _command(canonical_mid, "cmd-staged")
@@ -464,7 +480,9 @@ async def test_attach_tmdb_mapping_publishes_refresh_only_after_identity_finaliz
     mapping_service.attach_tmdb_mapping = AsyncMock(
         return_value=TMDBMappingAttachResult(canonical_media_id=canonical_mid, source_media_id=mid)
     )
-    mapping_service.finalize_tmdb_mapping_attach = Mock(side_effect=lambda _result: steps.append("finalize"))
+    mapping_service.finalize_tmdb_mapping_attach = Mock(
+        side_effect=lambda _result, **_kwargs: steps.append("finalize")
+    )
     mapping_service.rollback_tmdb_mapping_attach = Mock()
 
     result = await MediaExternalMappingApplicationService(
@@ -477,6 +495,7 @@ async def test_attach_tmdb_mapping_publishes_refresh_only_after_identity_finaliz
 
 @pytest.mark.asyncio
 async def test_attach_tmdb_mapping_keeps_refresh_after_post_commit_publish_failure(monkeypatch):
+    _mock_atomic_command_finalization(monkeypatch)
     mid = MediaID.parse("tmdb:tv:19995")
     canonical_mid = MediaID.parse("tmdb:tv:12345")
     staged = _command(canonical_mid, "cmd-staged-retry")
@@ -524,6 +543,7 @@ async def test_attach_tmdb_mapping_keeps_refresh_after_post_commit_publish_failu
 
 @pytest.mark.asyncio
 async def test_attach_tmdb_mapping_publishes_refresh_after_snapshot_failure(monkeypatch):
+    _mock_atomic_command_finalization(monkeypatch)
     mid = MediaID.parse("tmdb:tv:19996")
     canonical_mid = MediaID.parse("tmdb:tv:12346")
     staged = _command(canonical_mid, "cmd-snapshot-retry")
@@ -565,5 +585,6 @@ async def test_attach_tmdb_mapping_publishes_refresh_after_snapshot_failure(monk
     ).attach_tmdb_mapping(mid, tmdb_id=12346, season_number=1)
 
     assert result.command.status == CommandStatus.QUEUED
-    publish_mock.assert_awaited_once_with(staged)
+    assert publish_mock.await_args.args[0].id == staged.id
+    assert publish_mock.await_args.args[0].status == CommandStatus.READY
     discard_mock.assert_not_awaited()

--- a/backend/tests/test_external_mapping_tmdb.py
+++ b/backend/tests/test_external_mapping_tmdb.py
@@ -316,6 +316,38 @@ async def test_attach_tmdb_mapping_rolls_back_pending_mapping():
 
 
 @pytest.mark.asyncio
+async def test_attach_tmdb_mapping_rollback_restores_existing_canonical_mapping():
+    source = MediaID.parse("tmdb:movie:19995")
+    canonical = MediaID.parse("tmdb:movie:12345")
+    previous_canonical = MediaExternalMappingRecord(
+        media_type="movie",
+        media_id=canonical,
+        tmdb_id=12345,
+        imdb_id="tt-old-canonical",
+        douban_id="old-canonical-douban",
+        season_number=0,
+        episode_count_override=None,
+        updated_at=1.0,
+    )
+    repo = FakeMappingRepo(previous_canonical)
+    service = _service(repo=repo, provider_id=12345, imdb_id="tt-new")
+
+    result = await service.attach_tmdb_mapping(_media(source), tmdb_id=12345)
+    service.rollback_tmdb_mapping_attach(result)
+
+    assert result.previous_mapping is None
+    assert result.previous_canonical_mapping == previous_canonical
+    assert repo.upserts[-1] == {
+        "media_id": canonical,
+        "tmdb_id": 12345,
+        "imdb_id": "tt-old-canonical",
+        "douban_id": "old-canonical-douban",
+        "season_number": 0,
+        "episode_count_override": None,
+    }
+
+
+@pytest.mark.asyncio
 async def test_attach_tmdb_mapping_rolls_back_only_target_tv_season():
     mid = MediaID.parse("tmdb:tv:19995")
     repo = FakeMappingRepo()

--- a/backend/tests/test_external_mapping_tmdb.py
+++ b/backend/tests/test_external_mapping_tmdb.py
@@ -389,10 +389,15 @@ async def test_attach_tmdb_mapping_application_keeps_requested_tv_season(monkeyp
     canonical_mid = MediaID.parse("tmdb:tv:12345")
     enqueue_mock = AsyncMock(side_effect=lambda media_id, **_: _command(media_id, "cmd-season"))
     apply_snapshot_mock = AsyncMock()
+    refresh_profile_mock = AsyncMock()
     monkeypatch.setattr("app.services.application.workflows.media_external_mapping.service.profile_refresh_command_service.enqueue", enqueue_mock)
     monkeypatch.setattr(
         "app.services.application.workflows.media_external_mapping.service.media_service.simple_info",
         AsyncMock(return_value=_media(mid, season_number=2)),
+    )
+    monkeypatch.setattr(
+        "app.services.application.workflows.media_external_mapping.service.media_service.refresh_profile",
+        refresh_profile_mock,
     )
     monkeypatch.setattr(
         "app.services.application.workflows.media_external_mapping.service.media_service.apply_source_mapping_snapshot",
@@ -412,6 +417,7 @@ async def test_attach_tmdb_mapping_application_keeps_requested_tv_season(monkeyp
         season_number=3,
         episode_count_override=8,
     )
+    refresh_profile_mock.assert_awaited_once_with(canonical_mid, season_number=3)
     enqueue_mock.assert_awaited_once_with(
         canonical_mid,
         season_number=3,

--- a/backend/tests/test_external_mapping_tmdb.py
+++ b/backend/tests/test_external_mapping_tmdb.py
@@ -379,6 +379,7 @@ async def test_attach_tmdb_mapping_uses_profile_refresh_command_service_force_re
         season_number=None,
         initiator=CommandInitiator.SYSTEM,
         force_requeue=True,
+        target_label="Test Media (2026)",
     )
     mapping_service.finalize_tmdb_mapping_attach.assert_called_once()
 
@@ -389,15 +390,10 @@ async def test_attach_tmdb_mapping_application_keeps_requested_tv_season(monkeyp
     canonical_mid = MediaID.parse("tmdb:tv:12345")
     enqueue_mock = AsyncMock(side_effect=lambda media_id, **_: _command(media_id, "cmd-season"))
     apply_snapshot_mock = AsyncMock()
-    refresh_profile_mock = AsyncMock()
     monkeypatch.setattr("app.services.application.workflows.media_external_mapping.service.profile_refresh_command_service.enqueue", enqueue_mock)
     monkeypatch.setattr(
         "app.services.application.workflows.media_external_mapping.service.media_service.simple_info",
         AsyncMock(return_value=_media(mid, season_number=2)),
-    )
-    monkeypatch.setattr(
-        "app.services.application.workflows.media_external_mapping.service.media_service.refresh_profile",
-        refresh_profile_mock,
     )
     monkeypatch.setattr(
         "app.services.application.workflows.media_external_mapping.service.media_service.apply_source_mapping_snapshot",
@@ -417,12 +413,12 @@ async def test_attach_tmdb_mapping_application_keeps_requested_tv_season(monkeyp
         season_number=3,
         episode_count_override=8,
     )
-    refresh_profile_mock.assert_awaited_once_with(canonical_mid, season_number=3)
     enqueue_mock.assert_awaited_once_with(
         canonical_mid,
         season_number=3,
         initiator=CommandInitiator.SYSTEM,
         force_requeue=True,
+        target_label="Test Media (2026)",
     )
     apply_snapshot_mock.assert_awaited_once_with(
         canonical_mid,

--- a/backend/tests/test_external_mapping_tmdb.py
+++ b/backend/tests/test_external_mapping_tmdb.py
@@ -520,3 +520,50 @@ async def test_attach_tmdb_mapping_keeps_refresh_after_post_commit_publish_failu
     mapping_service.finalize_tmdb_mapping_attach.assert_called_once()
     apply_snapshot.assert_awaited_once()
     discard_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_attach_tmdb_mapping_publishes_refresh_after_snapshot_failure(monkeypatch):
+    mid = MediaID.parse("tmdb:tv:19996")
+    canonical_mid = MediaID.parse("tmdb:tv:12346")
+    staged = _command(canonical_mid, "cmd-snapshot-retry")
+    staged.status = CommandStatus.STAGED
+    queued = staged.model_copy(update={"status": CommandStatus.QUEUED})
+    discard_mock = AsyncMock()
+    publish_mock = AsyncMock(return_value=queued)
+    monkeypatch.setattr(
+        "app.services.application.workflows.media_external_mapping.service.profile_refresh_command_service.enqueue",
+        AsyncMock(return_value=staged),
+    )
+    monkeypatch.setattr(
+        "app.services.application.workflows.media_external_mapping.service.profile_refresh_command_service.publish",
+        publish_mock,
+    )
+    monkeypatch.setattr(
+        "app.services.application.workflows.media_external_mapping.service.profile_refresh_command_service.discard",
+        discard_mock,
+    )
+    monkeypatch.setattr(
+        "app.services.application.workflows.media_external_mapping.service.media_service.simple_info",
+        AsyncMock(return_value=_media(mid, season_number=1)),
+    )
+    monkeypatch.setattr(
+        "app.services.application.workflows.media_external_mapping.service.media_service.apply_source_mapping_snapshot",
+        AsyncMock(side_effect=RuntimeError("database busy")),
+    )
+    mapping_service = Mock()
+    mapping_service.attach_tmdb_mapping = AsyncMock(
+        return_value=TMDBMappingAttachResult(
+            canonical_media_id=canonical_mid,
+            source_media_id=mid,
+        )
+    )
+    mapping_service.finalize_tmdb_mapping_attach = Mock()
+
+    result = await MediaExternalMappingApplicationService(
+        mapping_service=mapping_service
+    ).attach_tmdb_mapping(mid, tmdb_id=12346, season_number=1)
+
+    assert result.command.status == CommandStatus.QUEUED
+    publish_mock.assert_awaited_once_with(staged)
+    discard_mock.assert_not_awaited()

--- a/backend/tests/test_external_mapping_tmdb.py
+++ b/backend/tests/test_external_mapping_tmdb.py
@@ -473,3 +473,50 @@ async def test_attach_tmdb_mapping_publishes_refresh_only_after_identity_finaliz
 
     assert steps == ["finalize", "snapshot", "publish"]
     assert result.command.status == CommandStatus.QUEUED
+
+
+@pytest.mark.asyncio
+async def test_attach_tmdb_mapping_keeps_refresh_after_post_commit_publish_failure(monkeypatch):
+    mid = MediaID.parse("tmdb:tv:19995")
+    canonical_mid = MediaID.parse("tmdb:tv:12345")
+    staged = _command(canonical_mid, "cmd-staged-retry")
+    staged.status = CommandStatus.STAGED
+    discard_mock = AsyncMock()
+    monkeypatch.setattr(
+        "app.services.application.workflows.media_external_mapping.service.profile_refresh_command_service.enqueue",
+        AsyncMock(return_value=staged),
+    )
+    monkeypatch.setattr(
+        "app.services.application.workflows.media_external_mapping.service.profile_refresh_command_service.publish",
+        AsyncMock(side_effect=RuntimeError("database busy")),
+    )
+    monkeypatch.setattr(
+        "app.services.application.workflows.media_external_mapping.service.profile_refresh_command_service.discard",
+        discard_mock,
+    )
+    monkeypatch.setattr(
+        "app.services.application.workflows.media_external_mapping.service.media_service.simple_info",
+        AsyncMock(return_value=_media(mid, season_number=1)),
+    )
+    apply_snapshot = AsyncMock()
+    monkeypatch.setattr(
+        "app.services.application.workflows.media_external_mapping.service.media_service.apply_source_mapping_snapshot",
+        apply_snapshot,
+    )
+    mapping_service = Mock()
+    mapping_service.attach_tmdb_mapping = AsyncMock(
+        return_value=TMDBMappingAttachResult(
+            canonical_media_id=canonical_mid,
+            source_media_id=mid,
+        )
+    )
+    mapping_service.finalize_tmdb_mapping_attach = Mock()
+
+    with pytest.raises(RuntimeError, match="database busy"):
+        await MediaExternalMappingApplicationService(
+            mapping_service=mapping_service
+        ).attach_tmdb_mapping(mid, tmdb_id=12345, season_number=1)
+
+    mapping_service.finalize_tmdb_mapping_attach.assert_called_once()
+    apply_snapshot.assert_awaited_once()
+    discard_mock.assert_not_awaited()

--- a/backend/tests/test_external_mapping_tmdb.py
+++ b/backend/tests/test_external_mapping_tmdb.py
@@ -380,6 +380,7 @@ async def test_attach_tmdb_mapping_uses_profile_refresh_command_service_force_re
         initiator=CommandInitiator.SYSTEM,
         force_requeue=True,
         target_label="Test Media (2026)",
+        defer_publish=True,
     )
     mapping_service.finalize_tmdb_mapping_attach.assert_called_once()
 
@@ -419,6 +420,7 @@ async def test_attach_tmdb_mapping_application_keeps_requested_tv_season(monkeyp
         initiator=CommandInitiator.SYSTEM,
         force_requeue=True,
         target_label="Test Media (2026)",
+        defer_publish=True,
     )
     apply_snapshot_mock.assert_awaited_once_with(
         canonical_mid,
@@ -426,3 +428,48 @@ async def test_attach_tmdb_mapping_application_keeps_requested_tv_season(monkeyp
         douban_id=None,
         episode_count_override=8,
     )
+
+
+@pytest.mark.asyncio
+async def test_attach_tmdb_mapping_publishes_refresh_only_after_identity_finalization(monkeypatch):
+    mid = MediaID.parse("tmdb:tv:19994")
+    canonical_mid = MediaID.parse("tmdb:tv:12344")
+    staged = _command(canonical_mid, "cmd-staged")
+    staged.status = CommandStatus.STAGED
+    queued = staged.model_copy(update={"status": CommandStatus.QUEUED})
+    steps = []
+
+    async def publish(command):
+        assert command.id == staged.id
+        steps.append("publish")
+        return queued
+
+    monkeypatch.setattr(
+        "app.services.application.workflows.media_external_mapping.service.profile_refresh_command_service.enqueue",
+        AsyncMock(return_value=staged),
+    )
+    monkeypatch.setattr(
+        "app.services.application.workflows.media_external_mapping.service.profile_refresh_command_service.publish",
+        AsyncMock(side_effect=publish),
+    )
+    monkeypatch.setattr(
+        "app.services.application.workflows.media_external_mapping.service.media_service.simple_info",
+        AsyncMock(return_value=_media(mid, season_number=1)),
+    )
+    monkeypatch.setattr(
+        "app.services.application.workflows.media_external_mapping.service.media_service.apply_source_mapping_snapshot",
+        AsyncMock(side_effect=lambda *_args, **_kwargs: steps.append("snapshot")),
+    )
+    mapping_service = Mock()
+    mapping_service.attach_tmdb_mapping = AsyncMock(
+        return_value=TMDBMappingAttachResult(canonical_media_id=canonical_mid, source_media_id=mid)
+    )
+    mapping_service.finalize_tmdb_mapping_attach = Mock(side_effect=lambda _result: steps.append("finalize"))
+    mapping_service.rollback_tmdb_mapping_attach = Mock()
+
+    result = await MediaExternalMappingApplicationService(
+        mapping_service=mapping_service
+    ).attach_tmdb_mapping(mid, tmdb_id=12344, season_number=1)
+
+    assert steps == ["finalize", "snapshot", "publish"]
+    assert result.command.status == CommandStatus.QUEUED

--- a/backend/tests/test_media_identity_repository.py
+++ b/backend/tests/test_media_identity_repository.py
@@ -135,6 +135,58 @@ def test_merge_media_id_preserves_missing_target_season_mapping_fields():
     }
 
 
+def test_merge_media_id_accumulates_fields_from_multiple_conflicting_mappings():
+    source = MediaID.parse("tmdb:tv:123456787")
+    target = MediaID.parse("tmdb:tv:987654319")
+    another_source = MediaID.parse("douban:tv:multiple-source")
+
+    with SessionLocal.begin() as session:
+        session.execute(
+            text(
+                """
+                INSERT INTO media_external_mappings
+                (media_type, media_id, tmdb_id, imdb_id, douban_id, season_number,
+                 episode_count_override, updated_at)
+                VALUES
+                ('tv', :target, 987654319, null, null, 2, null, 1),
+                ('tv', :source, 123456787, 'tt123', null, 2, null, 1),
+                ('tv', :another_source, 123456787, null, 'multi-source-season-2', 2, 12, 1)
+                """
+            ),
+            {
+                "source": str(source),
+                "target": str(target),
+                "another_source": str(another_source),
+            },
+        )
+
+    MediaIdentityRepository().merge_media_id(source, target)
+
+    with SessionLocal() as session:
+        row = (
+            session.execute(
+                text(
+                    """
+                    SELECT media_id, tmdb_id, imdb_id, douban_id, episode_count_override
+                    FROM media_external_mappings
+                    WHERE media_id = :target AND season_number = 2
+                    """
+                ),
+                {"target": str(target)},
+            )
+            .mappings()
+            .one()
+        )
+
+    assert dict(row) == {
+        "media_id": str(target),
+        "tmdb_id": 987654319,
+        "imdb_id": "tt123",
+        "douban_id": "multi-source-season-2",
+        "episode_count_override": 12,
+    }
+
+
 def test_merge_media_id_does_not_replace_prefix_media_ids_in_embedded_text_or_json():
     source = MediaID.parse("tmdb:movie:1")
     target = MediaID.parse("tmdb:movie:456")

--- a/backend/tests/test_media_identity_repository.py
+++ b/backend/tests/test_media_identity_repository.py
@@ -89,6 +89,52 @@ def test_merge_media_id_drops_source_external_mapping_when_target_season_exists(
     ]
 
 
+def test_merge_media_id_preserves_missing_target_season_mapping_fields():
+    source = MediaID.parse("tmdb:tv:123456788")
+    target = MediaID.parse("tmdb:tv:987654320")
+
+    with SessionLocal.begin() as session:
+        session.execute(
+            text(
+                """
+                INSERT INTO media_external_mappings
+                (media_type, media_id, tmdb_id, imdb_id, douban_id, season_number,
+                 episode_count_override, updated_at)
+                VALUES
+                ('tv', :target, 987654320, null, null, 2, null, 1),
+                ('tv', :source, 123456788, 'tt123', 'source-season-2', 2, 12, 1)
+                """
+            ),
+            {"source": str(source), "target": str(target)},
+        )
+
+    MediaIdentityRepository().merge_media_id(source, target)
+
+    with SessionLocal() as session:
+        row = (
+            session.execute(
+                text(
+                    """
+                    SELECT media_id, tmdb_id, imdb_id, douban_id, episode_count_override
+                    FROM media_external_mappings
+                    WHERE media_id = :target AND season_number = 2
+                    """
+                ),
+                {"target": str(target)},
+            )
+            .mappings()
+            .one()
+        )
+
+    assert dict(row) == {
+        "media_id": str(target),
+        "tmdb_id": 987654320,
+        "imdb_id": "tt123",
+        "douban_id": "source-season-2",
+        "episode_count_override": 12,
+    }
+
+
 def test_merge_media_id_does_not_replace_prefix_media_ids_in_embedded_text_or_json():
     source = MediaID.parse("tmdb:movie:1")
     target = MediaID.parse("tmdb:movie:456")

--- a/backend/tests/test_media_identity_repository.py
+++ b/backend/tests/test_media_identity_repository.py
@@ -45,6 +45,50 @@ def test_merge_media_id_retargets_source_external_mapping():
     assert row["douban_id"] == "111"
 
 
+def test_merge_media_id_drops_source_external_mapping_when_target_season_exists():
+    source = MediaID.parse("tmdb:tv:123456789")
+    target = MediaID.parse("tmdb:tv:987654321")
+
+    with SessionLocal.begin() as session:
+        session.execute(
+            text(
+                """
+                INSERT INTO media_external_mappings
+                (media_type, media_id, tmdb_id, imdb_id, douban_id, season_number, updated_at)
+                VALUES
+                ('tv', :target, 987654321, 'tt456', 'target-season-1', 1, 1),
+                ('tv', :source, 123456789, 'tt123', 'source-season-1', 1, 1),
+                ('tv', :source, 123456789, 'tt123', 'source-season-3', 3, 1)
+                """
+            ),
+            {"source": str(source), "target": str(target)},
+        )
+
+    MediaIdentityRepository().merge_media_id(source, target)
+
+    with SessionLocal() as session:
+        rows = (
+            session.execute(
+                text(
+                    """
+                    SELECT media_id, tmdb_id, douban_id, season_number
+                    FROM media_external_mappings
+                    WHERE media_id IN (:source, :target)
+                    ORDER BY season_number, douban_id
+                    """
+                ),
+                {"source": str(source), "target": str(target)},
+            )
+            .mappings()
+            .all()
+        )
+
+    assert [dict(row) for row in rows] == [
+        {"media_id": str(target), "tmdb_id": 987654321, "douban_id": "target-season-1", "season_number": 1},
+        {"media_id": str(target), "tmdb_id": 987654321, "douban_id": "source-season-3", "season_number": 3},
+    ]
+
+
 def test_merge_media_id_does_not_replace_prefix_media_ids_in_embedded_text_or_json():
     source = MediaID.parse("tmdb:movie:1")
     target = MediaID.parse("tmdb:movie:456")

--- a/backend/tests/test_media_profile_service_simple_info.py
+++ b/backend/tests/test_media_profile_service_simple_info.py
@@ -3,7 +3,11 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
 import pytest
+from sqlalchemy import delete
 
+from app.db.repositories.media_profile_scope_repository import MediaProfileScopeRepository
+from app.db.sql.models import MediaProfileScopeORM
+from app.db.sql.session import SessionLocal
 from app.schemas.domain.media import EpisodeInfo, MediaFullInfo, MediaSeasonInfo, PersonInfo
 from app.schemas.domain.media_context import MediaCapabilities
 from app.schemas.domain.media_profile_scope import MediaProfileScope, MediaProfileScopeAiring
@@ -612,15 +616,10 @@ async def test_apply_source_mapping_snapshot_updates_existing_scope(monkeypatch)
     service = MediaProfileService(provider_service=None, schedule_service=MediaScheduleService())
     media_id = MediaID.parse("tmdb:tv:312823")
     profile = _ready_profile(media_id)
-    existing_scope = _scope(media_id, 2, episode_count=54, douban_id="36055705")
-    saved = []
-
-    async def fake_upsert_scope(next_scope):
-        saved.append(next_scope)
+    update_snapshot = AsyncMock(return_value=True)
 
     monkeypatch.setattr(service.profile_repo, "find_by_media_id", AsyncMock(return_value=profile))
-    monkeypatch.setattr(service.scope_repo, "find_by_media_id_and_season", AsyncMock(return_value=existing_scope))
-    monkeypatch.setattr(service.scope_repo, "upsert_scope", fake_upsert_scope)
+    monkeypatch.setattr(service.scope_repo, "update_mapping_snapshot", update_snapshot)
 
     await service.apply_source_mapping_snapshot(
         media_id,
@@ -629,9 +628,53 @@ async def test_apply_source_mapping_snapshot_updates_existing_scope(monkeypatch)
         episode_count_override=24,
     )
 
-    assert saved
-    assert saved[-1].douban_id == "36055705"
-    assert saved[-1].episode_count_override == 24
+    update_snapshot.assert_awaited_once()
+    assert update_snapshot.await_args.args == (media_id, 2)
+    assert update_snapshot.await_args.kwargs["douban_id"] is None
+    assert update_snapshot.await_args.kwargs["episode_count_override"] == 24
+    assert update_snapshot.await_args.kwargs["updated_at"] > 0
+
+
+@pytest.mark.asyncio
+async def test_mapping_snapshot_update_preserves_refreshed_scope_fields():
+    repo = MediaProfileScopeRepository()
+    media_id = MediaID.parse("tmdb:tv:312824")
+    scope = MediaProfileScope(
+        media_id=media_id,
+        season_number=2,
+        media_type=MediaType.tv,
+        name="Fresh provider title",
+        episode_count=54,
+        status_label="Returning Series",
+        douban_id="old-douban-id",
+        updated_at=100.0,
+    )
+    await repo.upsert_scope(scope)
+
+    try:
+        updated = await repo.update_mapping_snapshot(
+            media_id,
+            2,
+            douban_id="new-douban-id",
+            episode_count_override=24,
+            updated_at=200.0,
+        )
+        saved = await repo.find_by_media_id_and_season(media_id, 2)
+    finally:
+        with SessionLocal.begin() as session:
+            session.execute(
+                delete(MediaProfileScopeORM).where(
+                    MediaProfileScopeORM.media_id == str(media_id)
+                )
+            )
+
+    assert updated is True
+    assert saved is not None
+    assert saved.name == "Fresh provider title"
+    assert saved.episode_count == 54
+    assert saved.status_label == "Returning Series"
+    assert saved.douban_id == "new-douban-id"
+    assert saved.episode_count_override == 24
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_profile_refresh_command_service.py
+++ b/backend/tests/test_profile_refresh_command_service.py
@@ -158,6 +158,36 @@ async def test_force_requeue_reuses_existing_followup_uniq_key(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_deferred_profile_refresh_stays_staged_until_published(monkeypatch):
+    service = ProfileRefreshCommandService()
+    media_id = MediaID.parse("tmdb:movie:1")
+    staged = _profile_refresh_command(command_id="cmd-staged", status=CommandStatus.STAGED)
+    queued = staged.model_copy(update={"status": CommandStatus.QUEUED})
+    monkeypatch.setattr(
+        "app.services.application.workflows.profile_refresh.service.command_service.find_active_command_by_uniq_key",
+        AsyncMock(return_value=None),
+    )
+    create_mock = AsyncMock(return_value=staged)
+    monkeypatch.setattr(
+        "app.services.application.workflows.profile_refresh.service.command_service.create_staged_command",
+        create_mock,
+    )
+    publish_mock = AsyncMock(return_value=queued)
+    monkeypatch.setattr(
+        "app.services.application.workflows.profile_refresh.service.command_service.publish_staged_command",
+        publish_mock,
+    )
+
+    prepared = await service.enqueue(media_id, force_requeue=True, defer_publish=True)
+
+    assert prepared.status == CommandStatus.STAGED
+    create_mock.assert_awaited_once()
+    published = await service.publish(prepared)
+    assert published.status == CommandStatus.QUEUED
+    publish_mock.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_profile_refresh_api_uses_force_requeue(monkeypatch):
     media_id = MediaID.parse("tmdb:movie:1")
     command = _profile_refresh_command(command_id="cmd-new", status=CommandStatus.QUEUED)

--- a/backend/tests/test_profile_refresh_command_service.py
+++ b/backend/tests/test_profile_refresh_command_service.py
@@ -162,6 +162,7 @@ async def test_deferred_profile_refresh_stays_staged_until_published(monkeypatch
     service = ProfileRefreshCommandService()
     media_id = MediaID.parse("tmdb:movie:1")
     staged = _profile_refresh_command(command_id="cmd-staged", status=CommandStatus.STAGED)
+    ready = staged.model_copy(update={"status": CommandStatus.READY})
     queued = staged.model_copy(update={"status": CommandStatus.QUEUED})
     monkeypatch.setattr(
         "app.services.application.workflows.profile_refresh.service.command_service.find_active_command_by_uniq_key",
@@ -173,6 +174,11 @@ async def test_deferred_profile_refresh_stays_staged_until_published(monkeypatch
         create_mock,
     )
     publish_mock = AsyncMock(return_value=queued)
+    mark_ready_mock = AsyncMock(return_value=ready)
+    monkeypatch.setattr(
+        "app.services.application.workflows.profile_refresh.service.command_service.mark_staged_command_ready",
+        mark_ready_mock,
+    )
     monkeypatch.setattr(
         "app.services.application.workflows.profile_refresh.service.command_service.publish_staged_command",
         publish_mock,
@@ -184,7 +190,33 @@ async def test_deferred_profile_refresh_stays_staged_until_published(monkeypatch
     create_mock.assert_awaited_once()
     published = await service.publish(prepared)
     assert published.status == CommandStatus.QUEUED
+    mark_ready_mock.assert_awaited_once_with(staged.id)
     publish_mock.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_deferred_profile_refresh_remains_ready_when_publish_fails(monkeypatch):
+    service = ProfileRefreshCommandService()
+    staged = _profile_refresh_command(command_id="cmd-ready-retry", status=CommandStatus.STAGED)
+    ready = staged.model_copy(update={"status": CommandStatus.READY})
+    monkeypatch.setattr(
+        "app.services.application.workflows.profile_refresh.service.command_service.mark_staged_command_ready",
+        AsyncMock(return_value=ready),
+    )
+    monkeypatch.setattr(
+        "app.services.application.workflows.profile_refresh.service.command_service.publish_staged_command",
+        AsyncMock(side_effect=RuntimeError("database busy")),
+    )
+    get_mock = AsyncMock(return_value=ready)
+    monkeypatch.setattr(
+        "app.services.application.workflows.profile_refresh.service.command_service.get_command",
+        get_mock,
+    )
+
+    result = await service.publish(staged)
+
+    assert result.status == CommandStatus.READY
+    get_mock.assert_awaited_once_with(staged.id)
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_profile_refresh_command_service.py
+++ b/backend/tests/test_profile_refresh_command_service.py
@@ -262,7 +262,6 @@ async def test_deferred_profile_refresh_reuses_existing_ready_command(monkeypatc
     service = ProfileRefreshCommandService()
     media_id = MediaID.parse("tmdb:movie:1")
     ready = _profile_refresh_command(command_id="cmd-ready-existing", status=CommandStatus.READY)
-    reserved = ready.model_copy(update={"status": CommandStatus.STAGED})
     monkeypatch.setattr(
         "app.services.application.workflows.profile_refresh.service.command_service.find_active_command_by_uniq_key",
         AsyncMock(return_value=ready),
@@ -272,12 +271,6 @@ async def test_deferred_profile_refresh_reuses_existing_ready_command(monkeypatc
         "app.services.application.workflows.profile_refresh.service.command_service.create_staged_command",
         create_mock,
     )
-    reserve_mock = AsyncMock(return_value=reserved)
-    monkeypatch.setattr(
-        "app.services.application.workflows.profile_refresh.service.command_service.reserve_ready_command",
-        reserve_mock,
-    )
-
     result = await service.enqueue(
         media_id,
         force_requeue=True,
@@ -285,8 +278,7 @@ async def test_deferred_profile_refresh_reuses_existing_ready_command(monkeypatc
     )
 
     assert result.id == ready.id
-    assert result.status == CommandStatus.STAGED
-    reserve_mock.assert_awaited_once_with(ready.id)
+    assert result.status == CommandStatus.READY
     create_mock.assert_not_awaited()
 
 

--- a/backend/tests/test_profile_refresh_command_service.py
+++ b/backend/tests/test_profile_refresh_command_service.py
@@ -71,6 +71,44 @@ async def test_force_requeue_cancels_existing_queued_profile_refresh(monkeypatch
 
 
 @pytest.mark.asyncio
+async def test_deferred_force_requeue_keeps_existing_queued_until_finalize(monkeypatch):
+    service = ProfileRefreshCommandService()
+    media_id = MediaID.parse("tmdb:movie:1")
+    existing = _profile_refresh_command(
+        command_id="cmd-existing-queued",
+        status=CommandStatus.QUEUED,
+    )
+    staged = _profile_refresh_command(
+        command_id="cmd-staged-replacement",
+        status=CommandStatus.STAGED,
+    )
+    monkeypatch.setattr(
+        "app.services.application.workflows.profile_refresh.service.command_service.find_active_command_by_uniq_key",
+        AsyncMock(return_value=existing),
+    )
+    cancel_mock = AsyncMock()
+    monkeypatch.setattr(
+        "app.services.application.workflows.profile_refresh.service.command_service.cancel_command",
+        cancel_mock,
+    )
+    create_mock = AsyncMock(return_value=staged)
+    monkeypatch.setattr(
+        "app.services.application.workflows.profile_refresh.service.command_service.create_staged_command",
+        create_mock,
+    )
+
+    result = await service.enqueue(
+        media_id,
+        force_requeue=True,
+        defer_publish=True,
+    )
+
+    assert result.id == staged.id
+    cancel_mock.assert_not_awaited()
+    create_mock.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_force_requeue_submits_followup_when_existing_profile_refresh_is_running(monkeypatch):
     service = ProfileRefreshCommandService()
     media_id = MediaID.parse("tmdb:movie:1")

--- a/backend/tests/test_profile_refresh_command_service.py
+++ b/backend/tests/test_profile_refresh_command_service.py
@@ -234,3 +234,26 @@ async def test_profile_refresh_build_uses_identity_label_without_media_id_fallba
     assert command.target == MediaTarget(media_id=media_id, season_number=2)
     assert command.uniq_key == f"command:{CommandType.PROFILE_REFRESH.value}:{media_id}:season=2"
     resolve_mock.assert_awaited_once_with(media_id, season_number=2)
+
+
+@pytest.mark.asyncio
+async def test_profile_refresh_build_uses_supplied_label_before_profile_exists(monkeypatch):
+    media_id = MediaID.parse("tmdb:tv:272476")
+    resolve_mock = AsyncMock()
+    monkeypatch.setattr(
+        "app.services.application.commands.handlers.profile.media_service.resolve_execution_snapshot",
+        resolve_mock,
+    )
+
+    command = await ProfileRefreshCommandHandler().build(
+        CommandCreateRequest(
+            type=CommandType.PROFILE_REFRESH,
+            payload=ProfileRefreshCommandRequestPayload(
+                target=MediaTarget(media_id=media_id, season_number=2),
+                target_label="Test Show (2026)",
+            ),
+        )
+    )
+
+    assert command.target_label == "Test Show (2026)"
+    resolve_mock.assert_not_awaited()

--- a/backend/tests/test_profile_refresh_command_service.py
+++ b/backend/tests/test_profile_refresh_command_service.py
@@ -237,7 +237,36 @@ async def test_profile_refresh_build_uses_identity_label_without_media_id_fallba
 
 
 @pytest.mark.asyncio
-async def test_profile_refresh_build_uses_supplied_label_before_profile_exists(monkeypatch):
+async def test_profile_refresh_build_validates_manual_target_even_with_supplied_label(monkeypatch):
+    media_id = MediaID.parse("tmdb:tv:272476")
+    snapshot = MediaExecutionSnapshot(
+        media_id=media_id,
+        season_number=2,
+        title="Resolved Show",
+        year=2026,
+    )
+    resolve_mock = AsyncMock(return_value=snapshot)
+    monkeypatch.setattr(
+        "app.services.application.commands.handlers.profile.media_service.resolve_execution_snapshot",
+        resolve_mock,
+    )
+
+    command = await ProfileRefreshCommandHandler().build(
+        CommandCreateRequest(
+            type=CommandType.PROFILE_REFRESH,
+            payload=ProfileRefreshCommandRequestPayload(
+                target=MediaTarget(media_id=media_id, season_number=2),
+                target_label="Test Show (2026)",
+            ),
+        )
+    )
+
+    assert command.target_label == "Resolved Show (2026)"
+    resolve_mock.assert_awaited_once_with(media_id, season_number=2)
+
+
+@pytest.mark.asyncio
+async def test_profile_refresh_build_uses_system_supplied_label_before_profile_exists(monkeypatch):
     media_id = MediaID.parse("tmdb:tv:272476")
     resolve_mock = AsyncMock()
     monkeypatch.setattr(
@@ -248,6 +277,7 @@ async def test_profile_refresh_build_uses_supplied_label_before_profile_exists(m
     command = await ProfileRefreshCommandHandler().build(
         CommandCreateRequest(
             type=CommandType.PROFILE_REFRESH,
+            initiator=CommandInitiator.SYSTEM,
             payload=ProfileRefreshCommandRequestPayload(
                 target=MediaTarget(media_id=media_id, season_number=2),
                 target_label="Test Show (2026)",

--- a/backend/tests/test_profile_refresh_command_service.py
+++ b/backend/tests/test_profile_refresh_command_service.py
@@ -220,6 +220,39 @@ async def test_deferred_profile_refresh_remains_ready_when_publish_fails(monkeyp
 
 
 @pytest.mark.asyncio
+async def test_deferred_profile_refresh_reuses_existing_ready_command(monkeypatch):
+    service = ProfileRefreshCommandService()
+    media_id = MediaID.parse("tmdb:movie:1")
+    ready = _profile_refresh_command(command_id="cmd-ready-existing", status=CommandStatus.READY)
+    reserved = ready.model_copy(update={"status": CommandStatus.STAGED})
+    monkeypatch.setattr(
+        "app.services.application.workflows.profile_refresh.service.command_service.find_active_command_by_uniq_key",
+        AsyncMock(return_value=ready),
+    )
+    create_mock = AsyncMock()
+    monkeypatch.setattr(
+        "app.services.application.workflows.profile_refresh.service.command_service.create_staged_command",
+        create_mock,
+    )
+    reserve_mock = AsyncMock(return_value=reserved)
+    monkeypatch.setattr(
+        "app.services.application.workflows.profile_refresh.service.command_service.reserve_ready_command",
+        reserve_mock,
+    )
+
+    result = await service.enqueue(
+        media_id,
+        force_requeue=True,
+        defer_publish=True,
+    )
+
+    assert result.id == ready.id
+    assert result.status == CommandStatus.STAGED
+    reserve_mock.assert_awaited_once_with(ready.id)
+    create_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_profile_refresh_api_uses_force_requeue(monkeypatch):
     media_id = MediaID.parse("tmdb:movie:1")
     command = _profile_refresh_command(command_id="cmd-new", status=CommandStatus.QUEUED)

--- a/frontend/src/stores/operations.js
+++ b/frontend/src/stores/operations.js
@@ -8,7 +8,7 @@ import { useNotificationCenterStore } from '@/stores/notification-center'
 import { t } from '@/i18n'
 const RECENT_LIMIT = 20
 const FINISHED_STATUSES = ['succeeded', 'failed', 'cancelled']
-const ACTIVE_STATUSES = ['queued', 'running']
+const ACTIVE_STATUSES = ['ready', 'queued', 'running']
 
 function commandMediaTarget(command) {
   const target = command?.target

--- a/frontend/src/stores/operations.js
+++ b/frontend/src/stores/operations.js
@@ -196,7 +196,7 @@ export const useOperationsStore = defineStore('operations', () => {
   function cacheCommand(command) {
     if (!command?.id) return null
 
-    if (command.status === 'queued' || command.status === 'running') {
+    if (commandIsActive(command)) {
       activeCommands.value = [
         command,
         ...activeCommands.value.filter(item => item?.id !== command.id),


### PR DESCRIPTION
## Summary

- remove conflicting source-season external mappings before retargeting media identities
- refresh the selected TV season before finalizing a TMDB mapping attachment
- preserve the requested season and episode-count override through the refresh command
- document the intentional media refresh boundary exception

## Root cause

Merging a source TV identity into a canonical target could violate the season-scoped external-mapping uniqueness contract when both identities already contained the same season. The attach workflow could also finalize before the selected season profile was refreshed.

## Validation

- `./scripts/review_with_gates.sh`
- Backend quality checks passed
- 233 backend tests passed
- Frontend quality and production build passed

## Risk

The merge now deletes only source mapping rows whose target season already exists; non-conflicting source seasons are still retargeted.