### PR TITLE
Fix upgrade policy form hydration

### DIFF
--- a/frontend/src/composables/useSubscriptionDialog.js
+++ b/frontend/src/composables/useSubscriptionDialog.js
@@ -457,8 +457,8 @@ export function useSubscriptionDialog(props, emit) {
     loadingInitialData.value = true
     try {
       resetForm()
-      await Promise.all([fetchDirectories(), fetchFilterPresets(), fetchQualityProfiles(), fetchTags(), fetchSites()])
       await syncDialogUpgradeModeFromPolicy()
+      await Promise.all([fetchDirectories(), fetchFilterPresets(), fetchQualityProfiles(), fetchTags(), fetchSites()])
       await applyInitialConfig()
     } finally {
       loadingInitialData.value = false


### PR DESCRIPTION
## Summary
- hydrate the saved upgrade strategy before loading dependent dialog options
- preserve `consistent_skip_low` after reopening or refreshing the subscription dialog

## Validation
- `docker compose -f docker-compose.dev.yml exec -T frontend npm run quality`

## Risk
Low. This only changes the initialization order for the subscription dialog.