### PR TITLE
Skip downloading episodes during subscription upgrades

### DIFF
--- a/backend/app/services/domain/download/coverage.py
+++ b/backend/app/services/domain/download/coverage.py
@@ -18,7 +18,7 @@ def _positive_int(value) -> int | None:
     return None
 
 
-def list_episode_coverage_statuses() -> list[TaskStatus]:
+def list_active_episode_coverage_statuses() -> list[TaskStatus]:
     return [
         TaskStatus.PENDING,
         TaskStatus.DOWNLOADING,
@@ -26,6 +26,12 @@ def list_episode_coverage_statuses() -> list[TaskStatus]:
         TaskStatus.FINISHED,
         TaskStatus.TRANSFERRING,
         TaskStatus.MIGRATING,
+    ]
+
+
+def list_episode_coverage_statuses() -> list[TaskStatus]:
+    return [
+        *list_active_episode_coverage_statuses(),
         TaskStatus.COMPLETED,
     ]
 
@@ -148,7 +154,7 @@ class DownloadCoverageService:
         media_id: MediaID,
         season: int | None = None,
     ) -> set[int]:
-        tasks = await self._get_tasks(status=list_episode_coverage_statuses(), media_id=media_id)
+        tasks = await self._get_tasks(status=list_active_episode_coverage_statuses(), media_id=media_id)
         episodes: set[int] = set()
         for task in tasks:
             coverage = resolve_task_episode_coverage_detail(task)

--- a/backend/app/services/domain/subscription/resource_run_plan_service.py
+++ b/backend/app/services/domain/subscription/resource_run_plan_service.py
@@ -256,6 +256,8 @@ async def _compute_target_episodes(
         return target_episodes, required_scores
     min_upgrade_delta = int(upgrade_policy.min_upgrade_score_delta or 0)
     for episode, current_score in current_scores.items():
+        if int(episode) in downloading_episodes:
+            continue
         if current_score >= locked_score:
             continue
         target_episodes.add(int(episode))

--- a/backend/tests/test_subscription_execution_drift.py
+++ b/backend/tests/test_subscription_execution_drift.py
@@ -26,6 +26,7 @@ from app.schemas.media_id import MediaID
 from app.schemas.domain.subscription_run_result import SubscriptionRunResponse
 from app.schemas.runtime.subscription_runtime import SubscriptionPlanningStatus, SubscriptionRunPlan, SubscriptionRunPlanningResult
 from app.services.domain.download import download_service
+from app.services.domain.download.coverage import DownloadCoverageService
 from app.services.domain.resource.selection import ResourceSelectionPlan, partition_search_results, select_resources
 from app.services.application.workflows.resource_search import resource_search_service
 from app.services.application.workflows.subscription.run import SubscriptionRunApplicationService
@@ -639,6 +640,23 @@ async def test_compute_target_episodes_excludes_downloading_upgrade_episodes(mon
     assert plan is not None
     assert plan.target_episodes == {3}
     assert plan.required_scores == {3: 200}
+
+
+@pytest.mark.asyncio
+async def test_active_episode_coverage_excludes_completed_tasks():
+    downloading_task = _task_with_metadata(_video_metadata("Show.S01E02", [2]))
+    completed_task = _task_with_metadata(_video_metadata("Show.S01E03", [3])).model_copy(
+        update={"id": "task-completed", "status": TaskStatus.COMPLETED}
+    )
+    tasks = [downloading_task, completed_task]
+
+    async def get_tasks(*, status, media_id):
+        assert media_id == downloading_task.media_id
+        return [task for task in tasks if task.status in status]
+
+    service = DownloadCoverageService(get_tasks)
+
+    assert await service.list_active_episodes_by_media(downloading_task.media_id, season=1) == {2}
 
 
 def test_tv_disc_package_task_does_not_fallback_to_episode_one():

--- a/backend/tests/test_subscription_execution_drift.py
+++ b/backend/tests/test_subscription_execution_drift.py
@@ -599,6 +599,48 @@ async def test_compute_target_episodes_excludes_present_and_downloading_episodes
     assert plan.required_scores == {}
 
 
+@pytest.mark.asyncio
+async def test_compute_target_episodes_excludes_downloading_upgrade_episodes(monkeypatch):
+    sub = _subscription()
+    sub.filters = SubscriptionFilters(
+        upgrade_policy=UpgradePolicy(
+            enabled=True,
+            strategy="consistent_skip_low",
+            lock_mode="best_existing",
+        )
+    )
+    media = _media(episodes_count=3)
+
+    monkeypatch.setattr(
+        "app.services.domain.subscription.resource_run_plan_service.library_service.get_present_episodes",
+        AsyncMock(return_value={1, 2, 3}),
+    )
+    monkeypatch.setattr(
+        "app.services.domain.subscription.resource_run_plan_service.download_service.list_active_episodes_by_media",
+        AsyncMock(return_value={2}),
+    )
+    monkeypatch.setattr(
+        "app.services.domain.subscription.resource_run_plan_service.library_service.get_episode_attributes",
+        AsyncMock(
+            return_value={
+                1: [ResourceAttributes(resolution="2160p")],
+                2: [ResourceAttributes(resolution="1080p")],
+                3: [ResourceAttributes(resolution="1080p")],
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        "app.services.domain.subscription.resource_run_plan_service._upgrade_score",
+        lambda attrs, _quality_profile: 200 if attrs.resolution == "2160p" else 100,
+    )
+
+    plan = ((await resource_run_plan_service.build_subscription_plan(sub.model_copy(update={"media": media}))).plan)
+
+    assert plan is not None
+    assert plan.target_episodes == {3}
+    assert plan.required_scores == {3: 200}
+
+
 def test_tv_disc_package_task_does_not_fallback_to_episode_one():
     season, episodes = download_service.resolve_task_episode_coverage(_task_with_metadata(_disc_metadata(1)))
 


### PR DESCRIPTION
## Summary
- exclude actively downloading episodes when computing score-based upgrade targets
- prevent repeated attempts to add the same torrent while upgraded files are still downloading
- add regression coverage for mixed library and active-download upgrade state

## Validation
- `./aethera.sh test-backend tests/test_subscription_execution_drift.py -k 'compute_target_episodes'`
- `./scripts/review_with_gates.sh` (234 backend tests passed; frontend quality, lint, and build passed)
- live runtime check for `tmdb:tv:273114` returned `targetSatisfied` with no target episodes while E01-E17 were actively covered

## Risk
Low. Completion semantics remain unchanged; upgraded episodes still complete only after library import.