### PR TITLE
Fix episode NFO title refresh

### DIFF
--- a/backend/app/services/application/workflows/media_server_sync/nfo_plan.py
+++ b/backend/app/services/application/workflows/media_server_sync/nfo_plan.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -11,6 +12,9 @@ from app.services.domain.library.sidecar_files import library_sidecar_files
 from app.services.domain.media import media_service
 from app.services.integration.media_server import nfo as media_server_nfo
 from app.services.integration.media_server import nfo_inspection
+
+CJK_EPISODE_PREFIX_CODEPOINT = 31532
+CJK_EPISODE_SUFFIX_CODEPOINT = 38598
 
 
 @dataclass(frozen=True)
@@ -158,6 +162,7 @@ class MediaServerSyncNfoPlanService:
                 continue
             episode_number = int(target.episode_number)
             episode_info = await media_service.get_episode_info_for_media(media, season_number, episode_number)
+            episode_info = self._with_schedule_episode_title(media, episode_info, season_number, episode_number)
             item = (episode_number, episode_info)
             if fallback is None:
                 fallback = item
@@ -218,8 +223,14 @@ class MediaServerSyncNfoPlanService:
                 return True
             episode_number = int(target.episode_number)
             episode_info = await media_service.get_episode_info_for_media(media, season_number, episode_number)
-            require_title, require_plot = self._episode_required_fields(episode_info, season_details, episode_number)
-            if not nfo_inspection.is_episode_nfo_complete(path, require_title=require_title, require_plot=require_plot):
+            episode_info = self._with_schedule_episode_title(media, episode_info, season_number, episode_number)
+            title, overview = self._episode_expected_fields(episode_info, season_details, episode_number)
+            if not nfo_inspection.is_episode_nfo_complete(
+                path,
+                require_title=bool(title),
+                require_plot=bool(overview),
+                expected_title=title,
+            ):
                 return True
         return False
 
@@ -235,6 +246,15 @@ class MediaServerSyncNfoPlanService:
         season_details: SeasonDetails | None,
         episode_number: int,
     ) -> tuple[bool, bool]:
+        title, overview = self._episode_expected_fields(episode_info, season_details, episode_number)
+        return (bool(title), bool(overview))
+
+    def _episode_expected_fields(
+        self,
+        episode_info: EpisodeInfo | None,
+        season_details: SeasonDetails | None,
+        episode_number: int,
+    ) -> tuple[str, str]:
         title = str(episode_info.title or "").strip() if episode_info else ""
         overview = str(episode_info.overview or "").strip() if episode_info else ""
         if (not title or not overview) and season_details:
@@ -244,7 +264,56 @@ class MediaServerSyncNfoPlanService:
                 title = title or str(episode.title or "").strip()
                 overview = overview or str(episode.overview or "").strip()
                 break
-        return (bool(title), bool(overview))
+        return (title, overview)
+
+    def _with_schedule_episode_title(
+        self,
+        media: MediaFullInfo,
+        episode_info: EpisodeInfo | None,
+        season_number: int,
+        episode_number: int,
+    ) -> EpisodeInfo | None:
+        current_title = str(episode_info.title or "").strip() if episode_info else ""
+        if current_title and not self._is_placeholder_episode_title(current_title, episode_number):
+            return episode_info
+        schedule_title = next(
+            (
+                str(airing.episode_title or "").strip()
+                for airing in media.airings
+                if airing.kind == "tv_episode_air"
+                and airing.season_number == season_number
+                and airing.episode_number == episode_number
+                and str(airing.episode_title or "").strip()
+            ),
+            "",
+        )
+        if not schedule_title or self._is_placeholder_episode_title(schedule_title, episode_number):
+            return episode_info
+        if episode_info:
+            return episode_info.model_copy(update={"title": schedule_title})
+        return EpisodeInfo(
+            season_number=season_number,
+            episode_number=episode_number,
+            title=schedule_title,
+        )
+
+    @staticmethod
+    def _is_placeholder_episode_title(title: str, episode_number: int) -> bool:
+        normalized = re.sub(r"\s+", " ", title.strip()).casefold()
+        number = str(int(episode_number))
+        compact = normalized.replace(" ", "")
+        chinese_placeholder = (
+            len(compact) > 2
+            and ord(compact[0]) == CJK_EPISODE_PREFIX_CODEPOINT
+            and ord(compact[-1]) == CJK_EPISODE_SUFFIX_CODEPOINT
+            and compact[1:-1].lstrip("0") == number
+        )
+        patterns = (
+            rf"episode\s*0*{number}",
+            rf"ep\s*0*{number}",
+            rf"e\s*0*{number}",
+        )
+        return chinese_placeholder or any(re.fullmatch(pattern, normalized, flags=re.IGNORECASE) for pattern in patterns)
 
 
 media_server_sync_nfo_plan = MediaServerSyncNfoPlanService()

--- a/backend/app/services/application/workflows/media_server_sync/nfo_plan.py
+++ b/backend/app/services/application/workflows/media_server_sync/nfo_plan.py
@@ -196,8 +196,6 @@ class MediaServerSyncNfoPlanService:
                 continue
             if not include_incomplete:
                 continue
-            if nfo_inspection.is_episode_nfo_complete(path):
-                continue
             season_number, _ = self._episode_target_numbers(media, Path(destination_path), None)
             if season_number is None:
                 targets.extend(grouped_targets)
@@ -206,33 +204,22 @@ class MediaServerSyncNfoPlanService:
             if season_number not in season_details_map:
                 season_details = await media_service.get_season_details_for_media(media, season_number)
                 season_details_map[season_number] = season_details
-            if await self._episode_group_needs_sync(media, season_number, grouped_targets, season_details, path):
+            selected = await self._select_episode_nfo_target(media, season_number, grouped_targets, season_details)
+            if selected is None:
                 targets.extend(grouped_targets)
-        return targets
-
-    async def _episode_group_needs_sync(
-        self,
-        media: MediaFullInfo,
-        season_number: int,
-        targets: list[MediaServerSyncTargetFile],
-        season_details: SeasonDetails | None,
-        path: Path,
-    ) -> bool:
-        for target in targets:
-            if not target.episode_number:
-                return True
-            episode_number = int(target.episode_number)
-            episode_info = await media_service.get_episode_info_for_media(media, season_number, episode_number)
-            episode_info = self._with_schedule_episode_title(media, episode_info, season_number, episode_number)
+                continue
+            episode_number, episode_info = selected
             title, overview = self._episode_expected_fields(episode_info, season_details, episode_number)
+            existing_title = nfo_inspection.episode_nfo_title(path)
+            expected_title = title if self._is_placeholder_episode_title(existing_title, episode_number) else None
             if not nfo_inspection.is_episode_nfo_complete(
                 path,
                 require_title=bool(title),
                 require_plot=bool(overview),
-                expected_title=title,
+                expected_title=expected_title,
             ):
-                return True
-        return False
+                targets.extend(grouped_targets)
+        return targets
 
     def _episode_target_numbers(self, media: MediaFullInfo, path: Path, episode_number: int | None) -> tuple[int | None, int | None]:
         _, season_number = media_server_sync_target.get_season_dir_and_number(path, media)

--- a/backend/app/services/application/workflows/media_server_sync/nfo_plan.py
+++ b/backend/app/services/application/workflows/media_server_sync/nfo_plan.py
@@ -196,6 +196,14 @@ class MediaServerSyncNfoPlanService:
                 continue
             if not include_incomplete:
                 continue
+            existing_title = nfo_inspection.episode_nfo_title(path)
+            has_placeholder_title = any(
+                target.episode_number is not None
+                and self._is_placeholder_episode_title(existing_title, int(target.episode_number))
+                for target in grouped_targets
+            )
+            if nfo_inspection.is_episode_nfo_complete(path) and not has_placeholder_title:
+                continue
             season_number, _ = self._episode_target_numbers(media, Path(destination_path), None)
             if season_number is None:
                 targets.extend(grouped_targets)
@@ -210,7 +218,6 @@ class MediaServerSyncNfoPlanService:
                 continue
             episode_number, episode_info = selected
             title, overview = self._episode_expected_fields(episode_info, season_details, episode_number)
-            existing_title = nfo_inspection.episode_nfo_title(path)
             expected_title = title if self._is_placeholder_episode_title(existing_title, episode_number) else None
             if not nfo_inspection.is_episode_nfo_complete(
                 path,

--- a/backend/app/services/application/workflows/media_server_sync/nfo_plan.py
+++ b/backend/app/services/application/workflows/media_server_sync/nfo_plan.py
@@ -197,11 +197,7 @@ class MediaServerSyncNfoPlanService:
             if not include_incomplete:
                 continue
             existing_title = nfo_inspection.episode_nfo_title(path)
-            has_placeholder_title = any(
-                target.episode_number is not None
-                and self._is_placeholder_episode_title(existing_title, int(target.episode_number))
-                for target in grouped_targets
-            )
+            has_placeholder_title = self._is_placeholder_episode_title(existing_title)
             if nfo_inspection.is_episode_nfo_complete(path) and not has_placeholder_title:
                 continue
             season_number, _ = self._episode_target_numbers(media, Path(destination_path), None)
@@ -218,7 +214,7 @@ class MediaServerSyncNfoPlanService:
                 continue
             episode_number, episode_info = selected
             title, overview = self._episode_expected_fields(episode_info, season_details, episode_number)
-            expected_title = title if self._is_placeholder_episode_title(existing_title, episode_number) else None
+            expected_title = title if has_placeholder_title else None
             if not nfo_inspection.is_episode_nfo_complete(
                 path,
                 require_title=bool(title),
@@ -292,20 +288,22 @@ class MediaServerSyncNfoPlanService:
         )
 
     @staticmethod
-    def _is_placeholder_episode_title(title: str, episode_number: int) -> bool:
+    def _is_placeholder_episode_title(title: str, episode_number: int | None = None) -> bool:
         normalized = re.sub(r"\s+", " ", title.strip()).casefold()
-        number = str(int(episode_number))
         compact = normalized.replace(" ", "")
+        placeholder_number = compact[1:-1] if len(compact) > 2 else ""
         chinese_placeholder = (
             len(compact) > 2
             and ord(compact[0]) == CJK_EPISODE_PREFIX_CODEPOINT
             and ord(compact[-1]) == CJK_EPISODE_SUFFIX_CODEPOINT
-            and compact[1:-1].lstrip("0") == number
+            and placeholder_number.isdigit()
+            and (episode_number is None or placeholder_number.lstrip("0") == str(int(episode_number)))
         )
+        number_pattern = r"\d+" if episode_number is None else rf"0*{int(episode_number)}"
         patterns = (
-            rf"episode\s*0*{number}",
-            rf"ep\s*0*{number}",
-            rf"e\s*0*{number}",
+            rf"episode\s*{number_pattern}",
+            rf"ep\s*{number_pattern}",
+            rf"e\s*{number_pattern}",
         )
         return chinese_placeholder or any(re.fullmatch(pattern, normalized, flags=re.IGNORECASE) for pattern in patterns)
 

--- a/backend/app/services/application/workflows/media_server_sync/nfo_plan.py
+++ b/backend/app/services/application/workflows/media_server_sync/nfo_plan.py
@@ -162,7 +162,13 @@ class MediaServerSyncNfoPlanService:
                 continue
             episode_number = int(target.episode_number)
             episode_info = await media_service.get_episode_info_for_media(media, season_number, episode_number)
-            episode_info = self._with_schedule_episode_title(media, episode_info, season_number, episode_number)
+            episode_info = self._with_preferred_episode_title(
+                media,
+                episode_info,
+                season_details,
+                season_number,
+                episode_number,
+            )
             item = (episode_number, episode_info)
             if fallback is None:
                 fallback = item
@@ -256,17 +262,18 @@ class MediaServerSyncNfoPlanService:
                 break
         return (title, overview)
 
-    def _with_schedule_episode_title(
+    def _with_preferred_episode_title(
         self,
         media: MediaFullInfo,
         episode_info: EpisodeInfo | None,
+        season_details: SeasonDetails | None,
         season_number: int,
         episode_number: int,
     ) -> EpisodeInfo | None:
         current_title = str(episode_info.title or "").strip() if episode_info else ""
-        if current_title and not self._is_placeholder_episode_title(current_title, episode_number):
+        if current_title and not self._is_placeholder_episode_title(current_title):
             return episode_info
-        schedule_title = next(
+        preferred_title = next(
             (
                 str(airing.episode_title or "").strip()
                 for airing in media.airings
@@ -274,17 +281,29 @@ class MediaServerSyncNfoPlanService:
                 and airing.season_number == season_number
                 and airing.episode_number == episode_number
                 and str(airing.episode_title or "").strip()
+                and not self._is_placeholder_episode_title(str(airing.episode_title or ""))
             ),
             "",
         )
-        if not schedule_title or self._is_placeholder_episode_title(schedule_title, episode_number):
+        if not preferred_title and season_details:
+            preferred_title = next(
+                (
+                    str(episode.title or "").strip()
+                    for episode in season_details.episodes
+                    if episode.episode_number == episode_number
+                    and str(episode.title or "").strip()
+                    and not self._is_placeholder_episode_title(str(episode.title or ""))
+                ),
+                "",
+            )
+        if not preferred_title:
             return episode_info
         if episode_info:
-            return episode_info.model_copy(update={"title": schedule_title})
+            return episode_info.model_copy(update={"title": preferred_title})
         return EpisodeInfo(
             season_number=season_number,
             episode_number=episode_number,
-            title=schedule_title,
+            title=preferred_title,
         )
 
     @staticmethod

--- a/backend/app/services/application/workflows/media_server_sync/pipeline.py
+++ b/backend/app/services/application/workflows/media_server_sync/pipeline.py
@@ -62,17 +62,32 @@ class MediaServerSyncPipeline:
             return
 
         target_dir = Path(media_root_dir) if media_root_dir else media_server_sync_target.resolve_media_root_dir(media, file_path, transfer_results)
-        await self.apply_media_server_changes(
-            media_server=media_server,
-            changes=[
+        changes = [
+            MediaServerChange(
+                media_id=media.media_id,
+                target_path=str(target_dir),
+                change_type=change_type,
+                is_media_root=True,
+                reason="media_sync_refresh",
+            )
+        ]
+        seen_episode_paths: set[str] = set()
+        for target in transfer_results or []:
+            episode_nfo_path = str(Path(target.destination_path).with_suffix(".nfo"))
+            if not target.episode_number or episode_nfo_path in seen_episode_paths:
+                continue
+            seen_episode_paths.add(episode_nfo_path)
+            changes.append(
                 MediaServerChange(
                     media_id=media.media_id,
-                    target_path=str(target_dir),
+                    target_path=episode_nfo_path,
                     change_type=change_type,
-                    is_media_root=True,
-                    reason="media_sync_refresh",
+                    reason="episode_nfo_refresh",
                 )
-            ],
+            )
+        await self.apply_media_server_changes(
+            media_server=media_server,
+            changes=changes,
         )
 
     async def apply_media_server_changes(

--- a/backend/app/services/integration/media_server/nfo.py
+++ b/backend/app/services/integration/media_server/nfo.py
@@ -105,7 +105,11 @@ def build_episode_nfo(
         ET.SubElement(root, "runtime").text = runtime
     if tmdb_id:
         uniqueid = ET.SubElement(root, "uniqueid", type="tmdb", default="true")
-        uniqueid.text = str(episode_info.id if episode_info else f"tmdb-{tmdb_id}-{season_number}-{episode_number}")
+        uniqueid.text = str(
+            episode_info.id
+            if episode_info and episode_info.id
+            else f"tmdb-{tmdb_id}-{season_number}-{episode_number}"
+        )
     return _to_xml(root)
 
 

--- a/backend/app/services/integration/media_server/nfo_inspection.py
+++ b/backend/app/services/integration/media_server/nfo_inspection.py
@@ -39,6 +39,11 @@ def is_episode_nfo_complete(
     return _element_text(root, "title") == normalized_expected_title
 
 
+def episode_nfo_title(path: Path | None) -> str:
+    root = _parse_root(path)
+    return _element_text(root, "title") if root is not None else ""
+
+
 def _common_required_fields(media: MediaFullInfo) -> list[str]:
     fields = ["title"]
     if (media.overview or "").strip():

--- a/backend/app/services/integration/media_server/nfo_inspection.py
+++ b/backend/app/services/integration/media_server/nfo_inspection.py
@@ -23,13 +23,20 @@ def is_episode_nfo_complete(
     *,
     require_title: bool = True,
     require_plot: bool = True,
+    expected_title: str | None = None,
 ) -> bool:
     required_fields: list[str] = []
     if require_title:
         required_fields.append("title")
     if require_plot:
         required_fields.append("plot")
-    return _has_required_text(path, required_fields)
+    root = _parse_root(path)
+    if root is None or not _root_has_required_text(root, required_fields):
+        return False
+    normalized_expected_title = (expected_title or "").strip()
+    if not normalized_expected_title:
+        return True
+    return _element_text(root, "title") == normalized_expected_title
 
 
 def _common_required_fields(media: MediaFullInfo) -> list[str]:
@@ -40,16 +47,26 @@ def _common_required_fields(media: MediaFullInfo) -> list[str]:
 
 
 def _has_required_text(path: Path | None, field_names: list[str]) -> bool:
-    if path is None or not path.exists():
+    root = _parse_root(path)
+    if root is None:
         return False
-    try:
-        root = ET.parse(path).getroot()
-    except (ET.ParseError, OSError):
-        return False
+    return _root_has_required_text(root, field_names)
+
+
+def _root_has_required_text(root: ET.Element, field_names: list[str]) -> bool:
     for field_name in field_names:
         if not _element_text(root, field_name):
             return False
     return True
+
+
+def _parse_root(path: Path | None) -> ET.Element | None:
+    if path is None or not path.exists():
+        return None
+    try:
+        return ET.parse(path).getroot()
+    except (ET.ParseError, OSError):
+        return None
 
 
 def _element_text(root: ET.Element, field_name: str) -> str:

--- a/backend/tests/test_media_server_sync_boundaries.py
+++ b/backend/tests/test_media_server_sync_boundaries.py
@@ -604,7 +604,7 @@ async def test_media_server_sync_needs_rewrites_placeholder_episode_title(tmp_pa
     video.write_text("video")
     (tmp_path / "Show" / "tvshow.nfo").write_text(_tvshow_nfo_text())
     (tmp_path / "Show" / "Season 01" / "season.nfo").write_text(_season_nfo_text())
-    video.with_suffix(".nfo").write_text(_episode_nfo_text(title="第 16 集", plot=""))
+    video.with_suffix(".nfo").write_text(_episode_nfo_text(title="第 16 集", plot="Existing overview"))
     layout = LibraryMediaLayout(
         media_id=media.media_id,
         media_type=media.media_type,
@@ -624,7 +624,7 @@ async def test_media_server_sync_needs_rewrites_placeholder_episode_title(tmp_pa
             season_number=season_number,
             episode_number=episode_number,
             title="第 16 集",
-            overview="",
+            overview="Existing overview",
         )
 
     async def fake_season_details(media, season_number):

--- a/backend/tests/test_media_server_sync_boundaries.py
+++ b/backend/tests/test_media_server_sync_boundaries.py
@@ -11,6 +11,7 @@ from app.schemas.domain.media_context import MediaCapabilities
 from app.schemas.domain.media_server_sync import MediaServerSyncDetectNeeds, MediaServerSyncState
 from app.schemas.domain.media_server_sync import MediaServerSyncTargetFile
 from app.schemas.domain.media_types import MediaType
+from app.schemas.domain.schedule import ScheduleAiring
 from app.schemas.media_id import MediaID
 from app.services.application.workflows.media_server_sync.artifacts import media_server_sync_artifacts
 from app.services.application.workflows.media_server_sync.needs import media_server_sync_needs
@@ -581,6 +582,67 @@ async def test_media_server_sync_needs_does_not_require_unavailable_episode_plot
     )
 
     assert not needs.should_run
+
+
+@pytest.mark.asyncio
+async def test_media_server_sync_needs_rewrites_placeholder_episode_title(tmp_path: Path, monkeypatch):
+    media = _tv().model_copy(
+        update={
+            "airings": [
+                ScheduleAiring(
+                    date="2026-08-06",
+                    kind="tv_episode_air",
+                    season_number=1,
+                    episode_number=16,
+                    episode_title="佛爷入黑天门山手撕怪物",
+                )
+            ]
+        }
+    )
+    video = tmp_path / "Show" / "Season 01" / "Show.S01E16.mkv"
+    video.parent.mkdir(parents=True)
+    video.write_text("video")
+    (tmp_path / "Show" / "tvshow.nfo").write_text(_tvshow_nfo_text())
+    (tmp_path / "Show" / "Season 01" / "season.nfo").write_text(_season_nfo_text())
+    video.with_suffix(".nfo").write_text(_episode_nfo_text(title="第 16 集", plot=""))
+    layout = LibraryMediaLayout(
+        media_id=media.media_id,
+        media_type=media.media_type,
+        entries=[
+            LibraryMediaLayoutEntry(
+                file_id="file-16",
+                absolute_path=str(video),
+                is_video=True,
+                episode_numbers=[16],
+            )
+        ],
+        primary_anchor_file=str(video),
+    )
+
+    async def fake_episode_info(media, season_number, episode_number):
+        return EpisodeInfo(
+            season_number=season_number,
+            episode_number=episode_number,
+            title="第 16 集",
+            overview="",
+        )
+
+    async def fake_season_details(media, season_number):
+        return SeasonDetails(season_number=season_number)
+
+    monkeypatch.setattr("app.services.application.workflows.media_server_sync.nfo_plan.media_service.get_episode_info_for_media", fake_episode_info)
+    monkeypatch.setattr("app.services.application.workflows.media_server_sync.nfo_plan.media_service.get_season_details_for_media", fake_season_details)
+
+    needs = await media_server_sync_needs.detect(
+        media,
+        _state(media.media_id, last_success_at=time.time()),
+        MediaServerSyncConfig(),
+        layout,
+    )
+
+    assert needs.should_run
+    assert needs.missing_flags == ["episode_nfo_incomplete"]
+    assert [(item.destination_path, item.episode_number) for item in needs.transfer_results] == [(str(video), 16)]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_media_server_sync_nfo.py
+++ b/backend/tests/test_media_server_sync_nfo.py
@@ -279,6 +279,36 @@ async def test_multi_episode_nfo_check_uses_selected_episode_metadata(tmp_path: 
 
 
 @pytest.mark.asyncio
+async def test_complete_specific_episode_nfo_skips_provider_metadata(tmp_path: Path, monkeypatch):
+    episode_file = tmp_path / "Show" / "Season 01" / "Show.S01E01.mkv"
+    episode_file.parent.mkdir(parents=True)
+    episode_file.write_bytes(b"")
+    episode_file.with_suffix(".nfo").write_text(
+        "<episodedetails><title>Pilot</title><plot>Episode overview</plot></episodedetails>"
+    )
+
+    async def fail_episode_info(media, season_number, episode_number):
+        raise AssertionError("complete specific NFO must not load episode metadata")
+
+    async def fail_season_details(media, season_number):
+        raise AssertionError("complete specific NFO must not load season metadata")
+
+    monkeypatch.setattr(nfo_plan.media_service, "get_episode_info_for_media", fail_episode_info)
+    monkeypatch.setattr(nfo_plan.media_service, "get_season_details_for_media", fail_season_details)
+
+    targets = await nfo_plan.media_server_sync_nfo_plan.episode_nfo_targets_needing_sync(
+        _tv(),
+        MediaServerSyncInput(
+            transfer_results=[
+                MediaServerSyncTargetFile(destination_path=str(episode_file), episode_number=1),
+            ]
+        ),
+    )
+
+    assert targets == []
+
+
+@pytest.mark.asyncio
 async def test_generate_tv_nfo_replaces_placeholder_title_from_schedule(tmp_path: Path, monkeypatch):
     show_dir = tmp_path / "Show"
     season_dir = show_dir / "Season 01"

--- a/backend/tests/test_media_server_sync_nfo.py
+++ b/backend/tests/test_media_server_sync_nfo.py
@@ -279,6 +279,44 @@ async def test_multi_episode_nfo_check_uses_selected_episode_metadata(tmp_path: 
 
 
 @pytest.mark.asyncio
+async def test_multi_episode_nfo_replaces_non_selected_episode_placeholder(tmp_path: Path, monkeypatch):
+    episode_file = tmp_path / "Show" / "Season 10" / "Show.S10E17E18.mkv"
+    episode_file.parent.mkdir(parents=True)
+    episode_file.write_bytes(b"")
+    episode_file.with_suffix(".nfo").write_text(
+        "<episodedetails><title>Episode 18</title><plot>Part one overview</plot></episodedetails>"
+    )
+    episode_infos = {
+        17: EpisodeInfo(season_number=10, episode_number=17, title="The Last One", overview="Part one overview"),
+        18: EpisodeInfo(season_number=10, episode_number=18, title="The Second One", overview="Part two overview"),
+    }
+
+    async def fake_episode_info(media, season_number, episode_number):
+        return episode_infos[episode_number]
+
+    async def fake_season_details(media, season_number):
+        return SeasonDetails(season_number=season_number, episodes=list(episode_infos.values()))
+
+    monkeypatch.setattr(nfo_plan.media_service, "get_episode_info_for_media", fake_episode_info)
+    monkeypatch.setattr(nfo_plan.media_service, "get_season_details_for_media", fake_season_details)
+
+    targets = await nfo_plan.media_server_sync_nfo_plan.episode_nfo_targets_needing_sync(
+        _tv().model_copy(update={"season_number": 10}),
+        MediaServerSyncInput(
+            transfer_results=[
+                MediaServerSyncTargetFile(destination_path=str(episode_file), episode_number=17),
+                MediaServerSyncTargetFile(destination_path=str(episode_file), episode_number=18),
+            ]
+        ),
+    )
+
+    assert targets == [
+        MediaServerSyncTargetFile(destination_path=str(episode_file), episode_number=17),
+        MediaServerSyncTargetFile(destination_path=str(episode_file), episode_number=18),
+    ]
+
+
+@pytest.mark.asyncio
 async def test_complete_specific_episode_nfo_skips_provider_metadata(tmp_path: Path, monkeypatch):
     episode_file = tmp_path / "Show" / "Season 01" / "Show.S01E01.mkv"
     episode_file.parent.mkdir(parents=True)

--- a/backend/tests/test_media_server_sync_nfo.py
+++ b/backend/tests/test_media_server_sync_nfo.py
@@ -395,6 +395,58 @@ async def test_generate_tv_nfo_replaces_placeholder_title_from_schedule(tmp_path
 
 
 @pytest.mark.asyncio
+async def test_generate_tv_nfo_replaces_placeholder_title_from_season_details(tmp_path: Path, monkeypatch):
+    show_dir = tmp_path / "Show"
+    season_dir = show_dir / "Season 01"
+    season_dir.mkdir(parents=True)
+    episode_file = season_dir / "Show.S01E16.mkv"
+    episode_file.write_bytes(b"")
+    episode_file.with_suffix(".nfo").write_text(
+        "<episodedetails><title>Episode 16</title><plot>Episode overview</plot></episodedetails>"
+    )
+
+    async def fake_episode_info(media, season_number, episode_number):
+        return EpisodeInfo(
+            id=7578304,
+            season_number=season_number,
+            episode_number=episode_number,
+            title="Episode 16",
+            overview="Episode overview",
+        )
+
+    async def fake_season_details(media, season_number):
+        return SeasonDetails(
+            season_number=season_number,
+            episodes=[
+                EpisodeInfo(
+                    season_number=season_number,
+                    episode_number=16,
+                    title="佛爷入黑天门山手撕怪物",
+                    overview="Episode overview",
+                )
+            ],
+        )
+
+    monkeypatch.setattr(nfo_plan.media_service, "get_episode_info_for_media", fake_episode_info)
+    monkeypatch.setattr(nfo_plan.media_service, "get_season_details_for_media", fake_season_details)
+    target = MediaServerSyncTargetFile(destination_path=str(episode_file), episode_number=16)
+    sync_input = MediaServerSyncInput(transfer_results=[target])
+
+    assert await nfo_plan.media_server_sync_nfo_plan.episode_nfo_targets_needing_sync(_tv(), sync_input) == [target]
+
+    await nfo_plan.media_server_sync_nfo_plan.write_nfo_files(
+        _tv(),
+        str(episode_file),
+        transfer_results=[target],
+        media_root_dir=str(show_dir),
+    )
+
+    episode_nfo = ET.parse(episode_file.with_suffix(".nfo")).getroot()
+    assert episode_nfo.findtext("title") == "佛爷入黑天门山手撕怪物"
+    assert await nfo_plan.media_server_sync_nfo_plan.episode_nfo_targets_needing_sync(_tv(), sync_input) == []
+
+
+@pytest.mark.asyncio
 async def test_refresh_media_server_notifies_changed_episode_path(monkeypatch):
     pipeline_service = MediaServerSyncPipeline()
     captured_changes = []

--- a/backend/tests/test_media_server_sync_nfo.py
+++ b/backend/tests/test_media_server_sync_nfo.py
@@ -3,10 +3,12 @@ from pathlib import Path
 
 import pytest
 
+from app.schemas.config import JellyfinConfig
 from app.schemas.domain.media import EpisodeInfo, MediaFullInfo, SeasonDetails
 from app.schemas.domain.media_context import MediaCapabilities
-from app.schemas.domain.media_types import MediaType
 from app.schemas.domain.media_server_sync import MediaServerSyncTargetFile
+from app.schemas.domain.media_types import MediaType
+from app.schemas.domain.schedule import ScheduleAiring
 from app.schemas.media_id import MediaID
 from app.services.application.workflows.media_server_sync import nfo_plan
 from app.services.application.workflows.media_server_sync import pipeline
@@ -239,3 +241,77 @@ async def test_generate_tv_nfo_keeps_multi_episode_file_metadata_complete(tmp_pa
     assert episode_nfo.findtext("episode") == "17"
     assert episode_nfo.findtext("title") == "The Last One"
     assert episode_nfo.findtext("plot") == "Part one overview"
+
+
+@pytest.mark.asyncio
+async def test_generate_tv_nfo_replaces_placeholder_title_from_schedule(tmp_path: Path, monkeypatch):
+    show_dir = tmp_path / "Show"
+    season_dir = show_dir / "Season 01"
+    season_dir.mkdir(parents=True)
+    episode_file = season_dir / "Show.S01E16.mkv"
+    episode_file.write_bytes(b"")
+    media = _tv().model_copy(
+        update={
+            "airings": [
+                ScheduleAiring(
+                    date="2026-08-06",
+                    kind="tv_episode_air",
+                    season_number=1,
+                    episode_number=16,
+                    episode_title="佛爷入黑天门山手撕怪物",
+                )
+            ]
+        }
+    )
+
+    async def fake_episode_info(media, season_number, episode_number):
+        return EpisodeInfo(
+            id=7578304,
+            season_number=season_number,
+            episode_number=episode_number,
+            title="第 16 集",
+            overview="",
+        )
+
+    async def fake_season_details(media, season_number):
+        return SeasonDetails(season_number=season_number)
+
+    monkeypatch.setattr(nfo_plan.media_service, "get_episode_info_for_media", fake_episode_info)
+    monkeypatch.setattr(nfo_plan.media_service, "get_season_details_for_media", fake_season_details)
+
+    await nfo_plan.media_server_sync_nfo_plan.write_nfo_files(
+        media,
+        str(episode_file),
+        transfer_results=[MediaServerSyncTargetFile(destination_path=str(episode_file), episode_number=16)],
+        media_root_dir=str(show_dir),
+    )
+
+    episode_nfo = ET.parse(episode_file.with_suffix(".nfo")).getroot()
+    assert episode_nfo.findtext("title") == "佛爷入黑天门山手撕怪物"
+    assert episode_nfo.find("uniqueid[@type='tmdb']").text == "7578304"
+
+
+@pytest.mark.asyncio
+async def test_refresh_media_server_notifies_changed_episode_path(monkeypatch):
+    pipeline_service = MediaServerSyncPipeline()
+    captured_changes = []
+
+    async def fake_apply_media_server_changes(*, media_server, changes):
+        captured_changes.extend(changes)
+        return True
+
+    monkeypatch.setattr(pipeline_service, "apply_media_server_changes", fake_apply_media_server_changes)
+
+    episode_path = "/data/library/tv/Show/Season 01/Show.S01E16.mkv"
+    await pipeline_service.refresh_media_server(
+        _tv(),
+        episode_path,
+        [MediaServerSyncTargetFile(destination_path=episode_path, episode_number=16)],
+        media_server=JellyfinConfig(id="jellyfin"),
+        media_root_dir="/data/library/tv/Show",
+    )
+
+    assert [(change.target_path, change.reason) for change in captured_changes] == [
+        ("/data/library/tv/Show", "media_sync_refresh"),
+        ("/data/library/tv/Show/Season 01/Show.S01E16.nfo", "episode_nfo_refresh"),
+    ]

--- a/backend/tests/test_media_server_sync_nfo.py
+++ b/backend/tests/test_media_server_sync_nfo.py
@@ -6,7 +6,7 @@ import pytest
 from app.schemas.config import JellyfinConfig
 from app.schemas.domain.media import EpisodeInfo, MediaFullInfo, SeasonDetails
 from app.schemas.domain.media_context import MediaCapabilities
-from app.schemas.domain.media_server_sync import MediaServerSyncTargetFile
+from app.schemas.domain.media_server_sync import MediaServerSyncInput, MediaServerSyncTargetFile
 from app.schemas.domain.media_types import MediaType
 from app.schemas.domain.schedule import ScheduleAiring
 from app.schemas.media_id import MediaID
@@ -241,6 +241,41 @@ async def test_generate_tv_nfo_keeps_multi_episode_file_metadata_complete(tmp_pa
     assert episode_nfo.findtext("episode") == "17"
     assert episode_nfo.findtext("title") == "The Last One"
     assert episode_nfo.findtext("plot") == "Part one overview"
+
+
+@pytest.mark.asyncio
+async def test_multi_episode_nfo_check_uses_selected_episode_metadata(tmp_path: Path, monkeypatch):
+    episode_file = tmp_path / "Show" / "Season 10" / "Show.S10E17E18.mkv"
+    episode_file.parent.mkdir(parents=True)
+    episode_file.write_bytes(b"")
+    episode_file.with_suffix(".nfo").write_text(
+        "<episodedetails><title>The Last One</title><plot /></episodedetails>"
+    )
+    episode_infos = {
+        17: EpisodeInfo(season_number=10, episode_number=17, title="The Last One", overview=""),
+        18: EpisodeInfo(season_number=10, episode_number=18, title="The Second One", overview=""),
+    }
+
+    async def fake_episode_info(media, season_number, episode_number):
+        return episode_infos[episode_number]
+
+    async def fake_season_details(media, season_number):
+        return SeasonDetails(season_number=season_number, episodes=list(episode_infos.values()))
+
+    monkeypatch.setattr(nfo_plan.media_service, "get_episode_info_for_media", fake_episode_info)
+    monkeypatch.setattr(nfo_plan.media_service, "get_season_details_for_media", fake_season_details)
+
+    targets = await nfo_plan.media_server_sync_nfo_plan.episode_nfo_targets_needing_sync(
+        _tv().model_copy(update={"season_number": 10}),
+        MediaServerSyncInput(
+            transfer_results=[
+                MediaServerSyncTargetFile(destination_path=str(episode_file), episode_number=17),
+                MediaServerSyncTargetFile(destination_path=str(episode_file), episode_number=18),
+            ]
+        ),
+    )
+
+    assert targets == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- use season schedule titles when provider episode metadata still contains a generic placeholder
- detect title drift in existing episode NFO files so refreshed metadata is rewritten
- notify Jellyfin about the changed episode NFO path for an immediate item refresh
- preserve specific provider titles and TMDB episode identifiers

## Validation

- `./scripts/review_with_gates.sh`
- 243 backend architecture/drift tests passed
- frontend quality, lint, and production build passed
- targeted media-server sync tests passed (36 tests)
- live verification: 九门 S01E16 NFO and Jellyfin item updated to the specific episode title and overview