### PR TITLE
Improve notification center activity

### DIFF
--- a/backend/app/api/v1/events/list.py
+++ b/backend/app/api/v1/events/list.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel
 from app.api.deps import OptionalMediaIDParam
 from app.schemas.media_id import MediaID
 from app.schemas.domain.event import Event, EventCenterResponse, EventLevel, EventSource, EventType
+from app.services.application.views.event_center import event_center_view_service
 from app.services.audit.event_service import event_service
 
 router = APIRouter()
@@ -59,7 +60,7 @@ async def list_events(
 
 @router.get("/center", response_model=EventCenterResponse)
 async def get_event_center() -> EventCenterResponse:
-    return event_service.get_center()
+    return await event_center_view_service.get_center()
 
 
 @router.post("/center/acknowledge-all", response_model=EventAcknowledgeResponse)

--- a/backend/app/db/repositories/indexer_site_health_repository.py
+++ b/backend/app/db/repositories/indexer_site_health_repository.py
@@ -163,6 +163,18 @@ class IndexerSiteHealthRepository:
             if not self._matches_outcome(row, status) or row.status != "unhealthy" or not row.notify_pending:
                 session.rollback()
                 return False
+            previous_event_ids = self._matching_unhealthy_event_ids(session, event.correlation_id or "")
+            if previous_event_ids:
+                session.execute(
+                    sqlite_insert(EventAcknowledgementORM)
+                    .values(
+                        [
+                            {"event_id": event_id, "acknowledged_at": notified_at.isoformat()}
+                            for event_id in previous_event_ids
+                        ]
+                    )
+                    .on_conflict_do_nothing(index_elements=[EventAcknowledgementORM.event_id])
+                )
             EventRepository.add_to_session(session, event)
             for dispatch_record in dispatch_records:
                 EventDispatchRepository.add_to_session(session, dispatch_record)

--- a/backend/app/db/repositories/task_repository.py
+++ b/backend/app/db/repositories/task_repository.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime
 import logging
-from sqlalchemy import delete, desc, select, update
+from sqlalchemy import delete, desc, func, select, update
 
 from app.db.sql.models import TaskORM
 from app.db.sql.session import SessionLocal
@@ -223,6 +223,20 @@ class TaskRepository:
                 stmt = stmt.limit(limit)
             rows = session.execute(stmt).scalars().all()
             return [self._to_model(row) for row in rows]
+
+    async def count_with_filters(
+        self,
+        *,
+        status: list[str] | None = None,
+        media_id: MediaID | None = None,
+    ) -> int:
+        with SessionLocal() as session:
+            stmt = select(func.count()).select_from(TaskORM)
+            if media_id:
+                stmt = stmt.where(TaskORM.media_id == str(media_id))
+            if status:
+                stmt = stmt.where(TaskORM.status.in_(status))
+            return int(session.execute(stmt).scalar_one())
 
     async def list_media_ids(self) -> list[MediaID]:
         with SessionLocal() as session:

--- a/backend/app/schemas/domain/event.py
+++ b/backend/app/schemas/domain/event.py
@@ -140,7 +140,7 @@ class EventCenterDownload(BaseModel):
     status: TaskStatus
     progress: float = Field(default=0.0, ge=0.0, le=1.0)
     title: str
-    media: MediaIdentity | None = None
+    media: MediaIdentity
     created_at: datetime
     updated_at: datetime
 

--- a/backend/app/schemas/domain/event.py
+++ b/backend/app/schemas/domain/event.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, Field
 
 from app.schemas.media_id import MediaID
 from app.schemas.domain.action import ActionRecord
+from app.schemas.domain.download import TaskStatus
 from app.schemas.domain.media import MediaIdentity
 
 
@@ -128,12 +129,24 @@ class EventCenterBellState(str, Enum):
 
 class EventCenterSummary(BaseModel):
     active_action_count: int = 0
+    active_download_count: int = 0
     warning_event_count: int = 0
     error_event_count: int = 0
     bell_state: EventCenterBellState = EventCenterBellState.idle
 
 
+class EventCenterDownload(BaseModel):
+    id: str
+    status: TaskStatus
+    progress: float = Field(default=0.0, ge=0.0, le=1.0)
+    title: str
+    media: MediaIdentity | None = None
+    created_at: datetime
+    updated_at: datetime
+
+
 class EventCenterResponse(BaseModel):
     summary: EventCenterSummary
     active_actions: list[ActionRecord] = Field(default_factory=list)
+    active_downloads: list[EventCenterDownload] = Field(default_factory=list)
     events: list[Event] = Field(default_factory=list)

--- a/backend/app/services/application/views/event_center.py
+++ b/backend/app/services/application/views/event_center.py
@@ -6,11 +6,6 @@ from app.services.audit.event_service import event_service
 from app.services.domain.download import download_service
 
 
-ACTIVE_DOWNLOAD_STATUSES = [
-    TaskStatus.PENDING,
-    TaskStatus.DOWNLOADING,
-    TaskStatus.PAUSED,
-]
 RUNNING_DOWNLOAD_STATUSES = [
     TaskStatus.PENDING,
     TaskStatus.DOWNLOADING,
@@ -22,33 +17,41 @@ class EventCenterViewService:
     @staticmethod
     def _download_title(task: TaskData) -> str:
         context = task.context
-        search_result = context.search_result if context else None
+        search_result = context.search_result
         if search_result and search_result.title:
             return search_result.title
-        if context and context.resource_title:
+        if context.resource_title:
             return context.resource_title
         if task.metadata and task.metadata.name:
             return task.metadata.name
-        if context and context.media:
-            return context.media.title
-        return task.id
+        return context.media.title
 
     async def get_center(self) -> EventCenterResponse:
         center = event_service.get_center()
-        tasks, active_download_count = await asyncio.gather(
+        running_tasks, active_download_count = await asyncio.gather(
             download_service.get_tasks(
-                status=ACTIVE_DOWNLOAD_STATUSES,
+                status=RUNNING_DOWNLOAD_STATUSES,
                 limit=EVENT_CENTER_DOWNLOAD_LIMIT,
             ),
             download_service.count_tasks(status=RUNNING_DOWNLOAD_STATUSES),
         )
+        remaining_limit = EVENT_CENTER_DOWNLOAD_LIMIT - len(running_tasks)
+        paused_tasks = (
+            await download_service.get_tasks(
+                status=[TaskStatus.PAUSED],
+                limit=remaining_limit,
+            )
+            if remaining_limit > 0
+            else []
+        )
+        tasks = [*running_tasks, *paused_tasks]
         center.active_downloads = [
             EventCenterDownload(
                 id=task.id,
                 status=task.status,
                 progress=task.progress,
                 title=self._download_title(task),
-                media=task.context.media if task.context else None,
+                media=task.context.media,
                 created_at=task.created_at,
                 updated_at=task.updated_at,
             )

--- a/backend/app/services/application/views/event_center.py
+++ b/backend/app/services/application/views/event_center.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from app.schemas.domain.download import TaskData, TaskStatus
 from app.schemas.domain.event import EventCenterBellState, EventCenterDownload, EventCenterResponse
 from app.services.audit.event_service import event_service
@@ -8,6 +10,10 @@ ACTIVE_DOWNLOAD_STATUSES = [
     TaskStatus.PENDING,
     TaskStatus.DOWNLOADING,
     TaskStatus.PAUSED,
+]
+RUNNING_DOWNLOAD_STATUSES = [
+    TaskStatus.PENDING,
+    TaskStatus.DOWNLOADING,
 ]
 EVENT_CENTER_DOWNLOAD_LIMIT = 50
 
@@ -29,7 +35,13 @@ class EventCenterViewService:
 
     async def get_center(self) -> EventCenterResponse:
         center = event_service.get_center()
-        tasks = await download_service.get_tasks(status=ACTIVE_DOWNLOAD_STATUSES)
+        tasks, active_download_count = await asyncio.gather(
+            download_service.get_tasks(
+                status=ACTIVE_DOWNLOAD_STATUSES,
+                limit=EVENT_CENTER_DOWNLOAD_LIMIT,
+            ),
+            download_service.count_tasks(status=RUNNING_DOWNLOAD_STATUSES),
+        )
         center.active_downloads = [
             EventCenterDownload(
                 id=task.id,
@@ -40,10 +52,10 @@ class EventCenterViewService:
                 created_at=task.created_at,
                 updated_at=task.updated_at,
             )
-            for task in tasks[:EVENT_CENTER_DOWNLOAD_LIMIT]
+            for task in tasks
         ]
-        center.summary.active_download_count = len(tasks)
-        if center.summary.bell_state == EventCenterBellState.idle and tasks:
+        center.summary.active_download_count = active_download_count
+        if center.summary.bell_state == EventCenterBellState.idle and active_download_count:
             center.summary.bell_state = EventCenterBellState.running
         return center
 

--- a/backend/app/services/application/views/event_center.py
+++ b/backend/app/services/application/views/event_center.py
@@ -1,0 +1,51 @@
+from app.schemas.domain.download import TaskData, TaskStatus
+from app.schemas.domain.event import EventCenterBellState, EventCenterDownload, EventCenterResponse
+from app.services.audit.event_service import event_service
+from app.services.domain.download import download_service
+
+
+ACTIVE_DOWNLOAD_STATUSES = [
+    TaskStatus.PENDING,
+    TaskStatus.DOWNLOADING,
+    TaskStatus.PAUSED,
+]
+EVENT_CENTER_DOWNLOAD_LIMIT = 50
+
+
+class EventCenterViewService:
+    @staticmethod
+    def _download_title(task: TaskData) -> str:
+        context = task.context
+        search_result = context.search_result if context else None
+        if search_result and search_result.title:
+            return search_result.title
+        if context and context.resource_title:
+            return context.resource_title
+        if task.metadata and task.metadata.name:
+            return task.metadata.name
+        if context and context.media:
+            return context.media.title
+        return task.id
+
+    async def get_center(self) -> EventCenterResponse:
+        center = event_service.get_center()
+        tasks = await download_service.get_tasks(status=ACTIVE_DOWNLOAD_STATUSES)
+        center.active_downloads = [
+            EventCenterDownload(
+                id=task.id,
+                status=task.status,
+                progress=task.progress,
+                title=self._download_title(task),
+                media=task.context.media if task.context else None,
+                created_at=task.created_at,
+                updated_at=task.updated_at,
+            )
+            for task in tasks[:EVENT_CENTER_DOWNLOAD_LIMIT]
+        ]
+        center.summary.active_download_count = len(tasks)
+        if center.summary.bell_state == EventCenterBellState.idle and tasks:
+            center.summary.bell_state = EventCenterBellState.running
+        return center
+
+
+event_center_view_service = EventCenterViewService()

--- a/backend/app/services/domain/download/facade.py
+++ b/backend/app/services/domain/download/facade.py
@@ -100,6 +100,13 @@ class DownloadService:
             offset=offset,
         )
 
+    async def count_tasks(
+        self,
+        status: list[TaskStatus] | None = None,
+        media_id: MediaID | None = None,
+    ) -> int:
+        return await self.task_service.count_tasks(status=status, media_id=media_id)
+
     async def list_media_tasks_for_overview(self, *, status: list[TaskStatus] | None = None, media_id: MediaID | None = None) -> list[TaskData]:
         return await self.task_service.list_media_tasks_for_overview(status=status, media_id=media_id)
 

--- a/backend/app/services/domain/download/tasks.py
+++ b/backend/app/services/domain/download/tasks.py
@@ -137,6 +137,17 @@ class DownloadTaskService:
         )
         return self.enrich_tasks_with_downloader_info(tasks)
 
+    async def count_tasks(
+        self,
+        *,
+        status: list[TaskStatus] | None = None,
+        media_id: MediaID | None = None,
+    ) -> int:
+        return await self._repo.count_with_filters(
+            status=self.normalize_status_values(status),
+            media_id=media_id,
+        )
+
     async def list_media_tasks_for_overview(
         self,
         *,

--- a/backend/tests/test_download_task_service_status.py
+++ b/backend/tests/test_download_task_service_status.py
@@ -14,6 +14,7 @@ from app.services.integration.download.client import DownloadClientCapabilities
 class _FakeRepo:
     def __init__(self, tasks: list[TaskData]) -> None:
         self.tasks = {task.id: task for task in tasks}
+        self.count_filters = []
 
     async def find_by_ids(self, task_ids: list[str]) -> list[TaskData]:
         return [self.tasks[task_id] for task_id in task_ids if task_id in self.tasks]
@@ -23,6 +24,17 @@ class _FakeRepo:
 
     async def delete_by_id(self, task_id: str) -> bool:
         return self.tasks.pop(task_id, None) is not None
+
+    async def count_with_filters(self, *, status=None, media_id=None) -> int:
+        self.count_filters.append({"status": status, "media_id": media_id})
+        return len(
+            [
+                task
+                for task in self.tasks.values()
+                if (not status or task.status.value in status)
+                and (media_id is None or task.media_id == media_id)
+            ]
+        )
 
 
 class _FakeClient:
@@ -111,6 +123,25 @@ async def test_get_torrent_status_by_task_ids_assigns_shared_hash_status_to_all_
 
     assert result == {task_a.id: status, task_b.id: status}
     assert client.requested_hashes == [["shared-hash"]]
+
+
+@pytest.mark.asyncio
+async def test_count_tasks_uses_status_count_query_without_loading_task_rows():
+    task = _task("task-1")
+    repo = _FakeRepo([task])
+    service = DownloadTaskService(
+        repo,
+        _FakeClientFactory(_FakeClient([])),
+        downloader_display_map_provider=lambda: {},
+        refresh_completed_task_health=lambda *_: None,
+    )
+
+    count = await service.count_tasks(status=[TaskStatus.PENDING, TaskStatus.DOWNLOADING])
+
+    assert count == 1
+    assert repo.count_filters == [
+        {"status": [TaskStatus.PENDING.value, TaskStatus.DOWNLOADING.value], "media_id": None}
+    ]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_event_center.py
+++ b/backend/tests/test_event_center.py
@@ -138,11 +138,15 @@ async def test_event_center_includes_active_downloads_and_sets_running_state(mon
         "app.services.application.views.event_center.event_service",
         SimpleNamespace(get_center=lambda: EventCenterResponse(summary=EventCenterSummary())),
     )
-    calls = {}
+    calls = {"list": []}
 
     async def get_tasks(**kwargs):
-        calls["list"] = kwargs
-        return [task]
+        calls["list"].append(kwargs)
+        return (
+            [task]
+            if kwargs["status"] == [TaskStatus.PENDING, TaskStatus.DOWNLOADING]
+            else []
+        )
 
     async def count_tasks(**kwargs):
         calls["count"] = kwargs
@@ -159,19 +163,27 @@ async def test_event_center_includes_active_downloads_and_sets_running_state(mon
     assert center.summary.bell_state == EventCenterBellState.running
     assert center.active_downloads[0].title == "Show.S01E01"
     assert center.active_downloads[0].media == media
-    assert calls["list"]["limit"] == 50
-    assert calls["list"]["status"] == [TaskStatus.PENDING, TaskStatus.DOWNLOADING, TaskStatus.PAUSED]
+    assert calls["list"] == [
+        {"status": [TaskStatus.PENDING, TaskStatus.DOWNLOADING], "limit": 50},
+        {"status": [TaskStatus.PAUSED], "limit": 49},
+    ]
     assert calls["count"]["status"] == [TaskStatus.PENDING, TaskStatus.DOWNLOADING]
 
 
 @pytest.mark.asyncio
 async def test_event_center_lists_paused_download_without_running_signal(monkeypatch):
     service = EventCenterViewService()
+    media = MediaIdentity(
+        media_id=MediaID.parse("tmdb:tv:3"),
+        season_number=1,
+        title="Paused show",
+        year=2026,
+    )
     task = SimpleNamespace(
         id="task-paused",
         status=TaskStatus.PAUSED,
         progress=0.42,
-        context=SimpleNamespace(search_result=None, resource_title="Paused release", media=None),
+        context=SimpleNamespace(search_result=None, resource_title="Paused release", media=media),
         metadata=None,
         created_at=datetime(2026, 1, 1),
         updated_at=datetime(2026, 1, 2),
@@ -183,7 +195,9 @@ async def test_event_center_lists_paused_download_without_running_signal(monkeyp
     monkeypatch.setattr(
         "app.services.application.views.event_center.download_service",
         SimpleNamespace(
-            get_tasks=lambda **_kwargs: _async_value([task]),
+            get_tasks=lambda **kwargs: _async_value(
+                [task] if kwargs["status"] == [TaskStatus.PAUSED] else []
+            ),
             count_tasks=lambda **_kwargs: _async_value(0),
         ),
     )
@@ -193,6 +207,63 @@ async def test_event_center_lists_paused_download_without_running_signal(monkeyp
     assert center.summary.active_download_count == 0
     assert center.summary.bell_state == EventCenterBellState.idle
     assert [item.id for item in center.active_downloads] == ["task-paused"]
+    assert center.active_downloads[0].media == media
+
+
+@pytest.mark.asyncio
+async def test_event_center_prioritizes_running_downloads_before_paused_fillers(monkeypatch):
+    service = EventCenterViewService()
+    media = MediaIdentity(
+        media_id=MediaID.parse("tmdb:tv:4"),
+        season_number=1,
+        title="Show",
+        year=2026,
+    )
+
+    def task(task_id: str, status: TaskStatus):
+        return SimpleNamespace(
+            id=task_id,
+            status=status,
+            progress=0.42,
+            context=SimpleNamespace(search_result=None, resource_title=task_id, media=media),
+            metadata=None,
+            created_at=datetime(2026, 1, 1),
+            updated_at=datetime(2026, 1, 2),
+        )
+
+    running_task = task("running", TaskStatus.DOWNLOADING)
+    paused_tasks = [task(f"paused-{index}", TaskStatus.PAUSED) for index in range(60)]
+    calls = []
+
+    async def get_tasks(**kwargs):
+        calls.append(kwargs)
+        if kwargs["status"] == [TaskStatus.PENDING, TaskStatus.DOWNLOADING]:
+            return [running_task]
+        return paused_tasks[: kwargs["limit"]]
+
+    monkeypatch.setattr(
+        "app.services.application.views.event_center.event_service",
+        SimpleNamespace(get_center=lambda: EventCenterResponse(summary=EventCenterSummary())),
+    )
+    monkeypatch.setattr(
+        "app.services.application.views.event_center.download_service",
+        SimpleNamespace(
+            get_tasks=get_tasks,
+            count_tasks=lambda **_kwargs: _async_value(1),
+        ),
+    )
+
+    center = await service.get_center()
+
+    assert len(center.active_downloads) == 50
+    assert center.active_downloads[0].id == "running"
+    assert [item.id for item in center.active_downloads[1:]] == [
+        f"paused-{index}" for index in range(49)
+    ]
+    assert calls == [
+        {"status": [TaskStatus.PENDING, TaskStatus.DOWNLOADING], "limit": 50},
+        {"status": [TaskStatus.PAUSED], "limit": 49},
+    ]
 
 
 async def _async_value(value):

--- a/backend/tests/test_event_center.py
+++ b/backend/tests/test_event_center.py
@@ -1,8 +1,14 @@
 from datetime import datetime
 from types import SimpleNamespace
 
+import pytest
+
 from app.schemas.domain.action import ActionKind, ActionRecord, ActionStatus
-from app.schemas.domain.event import Event, EventCenterBellState, EventLevel, EventType
+from app.schemas.domain.download import TaskStatus
+from app.schemas.domain.event import Event, EventCenterBellState, EventCenterResponse, EventCenterSummary, EventLevel, EventType
+from app.schemas.domain.media import MediaIdentity
+from app.schemas.media_id import MediaID
+from app.services.application.views.event_center import EventCenterViewService
 from app.services.audit.action_service import ActionService
 from app.services.audit.event_service import EventService
 
@@ -108,3 +114,42 @@ def test_event_center_acknowledges_all_attention_events(monkeypatch):
     assert center.summary.error_event_count == 0
     assert center.summary.warning_event_count == 0
     assert center.events == []
+
+
+@pytest.mark.asyncio
+async def test_event_center_includes_active_downloads_and_sets_running_state(monkeypatch):
+    service = EventCenterViewService()
+    media = MediaIdentity(
+        media_id=MediaID.parse("tmdb:tv:2"),
+        season_number=1,
+        title="Show",
+        year=2026,
+    )
+    task = SimpleNamespace(
+        id="task-1",
+        status=TaskStatus.DOWNLOADING,
+        progress=0.42,
+        context=SimpleNamespace(search_result=None, resource_title="Show.S01E01", media=media),
+        metadata=None,
+        created_at=datetime(2026, 1, 1),
+        updated_at=datetime(2026, 1, 2),
+    )
+    monkeypatch.setattr(
+        "app.services.application.views.event_center.event_service",
+        SimpleNamespace(get_center=lambda: EventCenterResponse(summary=EventCenterSummary())),
+    )
+    monkeypatch.setattr(
+        "app.services.application.views.event_center.download_service",
+        SimpleNamespace(get_tasks=lambda **_kwargs: _async_value([task])),
+    )
+
+    center = await service.get_center()
+
+    assert center.summary.active_download_count == 1
+    assert center.summary.bell_state == EventCenterBellState.running
+    assert center.active_downloads[0].title == "Show.S01E01"
+    assert center.active_downloads[0].media == media
+
+
+async def _async_value(value):
+    return value

--- a/backend/tests/test_event_center.py
+++ b/backend/tests/test_event_center.py
@@ -138,9 +138,19 @@ async def test_event_center_includes_active_downloads_and_sets_running_state(mon
         "app.services.application.views.event_center.event_service",
         SimpleNamespace(get_center=lambda: EventCenterResponse(summary=EventCenterSummary())),
     )
+    calls = {}
+
+    async def get_tasks(**kwargs):
+        calls["list"] = kwargs
+        return [task]
+
+    async def count_tasks(**kwargs):
+        calls["count"] = kwargs
+        return 1
+
     monkeypatch.setattr(
         "app.services.application.views.event_center.download_service",
-        SimpleNamespace(get_tasks=lambda **_kwargs: _async_value([task])),
+        SimpleNamespace(get_tasks=get_tasks, count_tasks=count_tasks),
     )
 
     center = await service.get_center()
@@ -149,6 +159,40 @@ async def test_event_center_includes_active_downloads_and_sets_running_state(mon
     assert center.summary.bell_state == EventCenterBellState.running
     assert center.active_downloads[0].title == "Show.S01E01"
     assert center.active_downloads[0].media == media
+    assert calls["list"]["limit"] == 50
+    assert calls["list"]["status"] == [TaskStatus.PENDING, TaskStatus.DOWNLOADING, TaskStatus.PAUSED]
+    assert calls["count"]["status"] == [TaskStatus.PENDING, TaskStatus.DOWNLOADING]
+
+
+@pytest.mark.asyncio
+async def test_event_center_lists_paused_download_without_running_signal(monkeypatch):
+    service = EventCenterViewService()
+    task = SimpleNamespace(
+        id="task-paused",
+        status=TaskStatus.PAUSED,
+        progress=0.42,
+        context=SimpleNamespace(search_result=None, resource_title="Paused release", media=None),
+        metadata=None,
+        created_at=datetime(2026, 1, 1),
+        updated_at=datetime(2026, 1, 2),
+    )
+    monkeypatch.setattr(
+        "app.services.application.views.event_center.event_service",
+        SimpleNamespace(get_center=lambda: EventCenterResponse(summary=EventCenterSummary())),
+    )
+    monkeypatch.setattr(
+        "app.services.application.views.event_center.download_service",
+        SimpleNamespace(
+            get_tasks=lambda **_kwargs: _async_value([task]),
+            count_tasks=lambda **_kwargs: _async_value(0),
+        ),
+    )
+
+    center = await service.get_center()
+
+    assert center.summary.active_download_count == 0
+    assert center.summary.bell_state == EventCenterBellState.idle
+    assert [item.id for item in center.active_downloads] == ["task-paused"]
 
 
 async def _async_value(value):

--- a/backend/tests/test_indexer_site_health_alerts.py
+++ b/backend/tests/test_indexer_site_health_alerts.py
@@ -5,6 +5,7 @@ from sqlalchemy import delete, select
 from sqlalchemy.exc import IntegrityError
 
 from app.db.repositories.indexer_site_health_repository import IndexerSiteHealthRepository
+from app.db.repositories.event_repository import EventRepository
 from app.db.sql.models import (
     EventAcknowledgementORM,
     EventDispatchORM,
@@ -805,6 +806,55 @@ def test_emit_unhealthy_event_queues_dispatch_and_cooldown_atomically():
     assert persisted_dispatch is not None
     assert saved is not None
     assert saved.last_notified_at == checked_at
+
+
+def test_emit_unhealthy_event_acknowledges_previous_matching_alert():
+    repo = IndexerSiteHealthRepository()
+    checked_at = datetime.now()
+    correlation_id = "indexer:dedupe-indexer:site:dedupe-site:unhealthy"
+    status = IndexerSiteHealthStatus(
+        indexer_id="dedupe-indexer",
+        site_id="dedupe-site",
+        status="unhealthy",
+        checked_at=checked_at,
+        consecutive_failures=27,
+        notify_pending=True,
+    )
+    repo.upsert(status)
+    previous_event = Event(
+        id="previous-dedupe-warning",
+        type=EventTypes.INDEXER_SITE_UNHEALTHY,
+        level=EventLevel.warning,
+        correlation_id=correlation_id,
+    )
+    current_event = Event(
+        id="current-dedupe-warning",
+        type=EventTypes.INDEXER_SITE_UNHEALTHY,
+        level=EventLevel.warning,
+        correlation_id=correlation_id,
+    )
+    with SessionLocal.begin() as session:
+        EventRepository.add_to_session(session, previous_event)
+
+    applied = repo.emit_unhealthy_event_if_current(status, current_event, [], checked_at)
+
+    with SessionLocal.begin() as session:
+        acknowledged_ids = set(session.execute(select(EventAcknowledgementORM.event_id)).scalars().all())
+        persisted_current = session.get(EventORM, current_event.id)
+        session.execute(
+            delete(EventAcknowledgementORM).where(EventAcknowledgementORM.event_id == previous_event.id)
+        )
+        session.execute(delete(EventORM).where(EventORM.id.in_([previous_event.id, current_event.id])))
+        session.execute(
+            delete(IndexerSiteHealthORM).where(
+                IndexerSiteHealthORM.indexer_id == status.indexer_id,
+                IndexerSiteHealthORM.site_id == status.site_id,
+            )
+        )
+
+    assert applied is True
+    assert persisted_current is not None
+    assert acknowledged_ids == {previous_event.id}
 
 
 def test_emit_unhealthy_event_rolls_back_when_dispatch_queue_insert_fails():

--- a/frontend/src/components/NotificationCenterDialog.vue
+++ b/frontend/src/components/NotificationCenterDialog.vue
@@ -13,6 +13,7 @@
 
       <div class="flex flex-wrap items-center gap-item text-caption text-muted">
         <AppTag :label="$t('notificationCenter.runningCount', { count: summary.active_action_count || 0 })" tone="accent" />
+        <AppTag :label="$t('notificationCenter.downloadingCount', { count: summary.active_download_count || 0 })" tone="accent" />
         <AppTag :label="$t('notificationCenter.warningCount', { count: summary.warning_event_count || 0 })" tone="warn" />
         <AppTag :label="$t('notificationCenter.errorCount', { count: summary.error_event_count || 0 })" tone="danger" />
         <Button
@@ -245,22 +246,30 @@ function itemRecord(item) {
 
 function itemStatusLabel(item) {
   if (item?.kind === 'event') return t(`notificationCenter.levels.${itemRecord(item).level}`)
+  if (item?.kind === 'download') return t(`notificationCenter.downloadStatuses.${itemRecord(item).status}`)
   return getStatusLabel(itemRecord(item).status)
 }
 
 function itemStatusTone(item) {
   if (item?.kind === 'event') return itemRecord(item).level === 'error' ? 'danger' : 'warn'
+  if (item?.kind === 'download') return itemRecord(item).status === 'paused' ? 'warn' : 'accent'
   return getStatusTone(itemRecord(item).status)
 }
 
 function itemStatusIcon(item) {
   if (item?.kind === 'event') return itemRecord(item).level === 'error' ? 'pi pi-times-circle' : 'pi pi-exclamation-triangle'
+  if (item?.kind === 'download') {
+    if (itemRecord(item).status === 'paused') return 'pi pi-pause-circle'
+    if (itemRecord(item).status === 'pending') return 'pi pi-clock'
+    return 'pi pi-spin pi-spinner'
+  }
   return itemRecord(item).status === 'running' ? 'pi pi-spin pi-spinner' : ''
 }
 
 function itemTypeLabel(item) {
   const record = itemRecord(item)
   if (item?.kind === 'event') return eventTypeLabel(record)
+  if (item?.kind === 'download') return t('notificationCenter.downloadType')
   return getActionTypeLabel(record)
 }
 
@@ -271,18 +280,28 @@ function itemTarget(item) {
 
 function itemMessage(item) {
   const record = itemRecord(item)
-  return item?.kind === 'event' ? eventMessage(record) : actionMessage(record)
+  if (item?.kind === 'event') return eventMessage(record)
+  if (item?.kind === 'download') {
+    return t('notificationCenter.downloadMessage', {
+      title: record.title || t('notificationCenter.noMessage'),
+      progress: Math.round(Number(record.progress || 0) * 100),
+    })
+  }
+  return actionMessage(record)
 }
 
 function itemTimestamp(item) {
   const record = itemRecord(item)
-  return item?.kind === 'event' ? record.ts : actionTimestamp(record)
+  if (item?.kind === 'event') return record.ts
+  if (item?.kind === 'download') return record.updated_at || record.created_at
+  return actionTimestamp(record)
 }
 
 function itemMetaText(item) {
   if (item?.kind === 'event') {
     return t('notificationCenter.eventMeta')
   }
+  if (item?.kind === 'download') return t('notificationCenter.downloadMeta')
   return t('notificationCenter.runningMeta')
 }
 

--- a/frontend/src/composables/useAppShell.js
+++ b/frontend/src/composables/useAppShell.js
@@ -49,7 +49,8 @@ export function useAppShell() {
       return t('notificationCenter.tooltipWarning', { count: summary.value.warning_event_count || 0 })
     }
     if (bellState.value === 'running') {
-      return t('notificationCenter.tooltipRunning', { count: summary.value.active_action_count || 0 })
+      const count = (summary.value.active_action_count || 0) + (summary.value.active_download_count || 0)
+      return t('notificationCenter.tooltipRunning', { count })
     }
     return t('notificationCenter.tooltipIdle')
   })

--- a/frontend/src/i18n/locales/en-US.js
+++ b/frontend/src/i18n/locales/en-US.js
@@ -1756,7 +1756,9 @@ export default {
     noRunningDescription: 'No services are running right now',
     eventMeta: 'Event',
     runningMeta: 'Processing',
+    downloadMeta: 'Download task',
     runningCount: 'Running {count}',
+    downloadingCount: 'Downloading {count}',
     warningCount: 'Warnings {count}',
     errorCount: 'Errors {count}',
     markRead: 'Mark as read',
@@ -1765,6 +1767,13 @@ export default {
     tooltipWarning: 'Notification center: {count} warnings',
     tooltipRunning: 'Notification center: {count} running',
     tooltipIdle: 'Notification center',
+    downloadType: 'Download task',
+    downloadMessage: '{title} · {progress}%',
+    downloadStatuses: {
+      pending: 'Pending',
+      downloading: 'Downloading',
+      paused: 'Paused',
+    },
     levels: {
       warning: 'Warning',
       error: 'Error',

--- a/frontend/src/i18n/locales/zh-CN.js
+++ b/frontend/src/i18n/locales/zh-CN.js
@@ -1757,7 +1757,9 @@ export default {
     noRunningDescription: '当前没有正在运行的服务',
     eventMeta: '事件',
     runningMeta: '正在处理',
+    downloadMeta: '下载任务',
     runningCount: '运行中 {count}',
+    downloadingCount: '下载中 {count}',
     warningCount: '警告 {count}',
     errorCount: '错误 {count}',
     markRead: '标为已读',
@@ -1766,6 +1768,13 @@ export default {
     tooltipWarning: '通知中心：{count} 个警告',
     tooltipRunning: '通知中心：{count} 个任务运行中',
     tooltipIdle: '通知中心',
+    downloadType: '下载任务',
+    downloadMessage: '{title} · {progress}%',
+    downloadStatuses: {
+      pending: '等待下载',
+      downloading: '下载中',
+      paused: '已暂停',
+    },
     levels: {
       warning: '警告',
       error: '错误',

--- a/frontend/src/stores/notification-center.js
+++ b/frontend/src/stores/notification-center.js
@@ -6,6 +6,7 @@ import { t } from '@/i18n'
 
 const EMPTY_SUMMARY = {
   active_action_count: 0,
+  active_download_count: 0,
   warning_event_count: 0,
   error_event_count: 0,
   bell_state: 'idle',
@@ -16,6 +17,7 @@ export const useNotificationCenterStore = defineStore('notification-center', () 
   const visible = ref(false)
   const summary = ref({ ...EMPTY_SUMMARY })
   const activeActions = ref([])
+  const activeDownloads = ref([])
   const events = ref([])
   const loading = ref(false)
   const markingAllRead = ref(false)
@@ -33,10 +35,17 @@ export const useNotificationCenterStore = defineStore('notification-center', () 
         timestamp: event.ts,
         record: event,
       })),
+      ...activeDownloads.value.map(download => ({
+        id: `download:${download.id}`,
+        kind: 'download',
+        priority: 1,
+        timestamp: download.updated_at || download.created_at,
+        record: download,
+      })),
       ...activeActions.value.map(action => ({
         id: `action:${action.id}`,
         kind: 'action',
-        priority: 1,
+        priority: 2,
         timestamp: action.started_at || action.ts,
         record: action,
       })),
@@ -49,7 +58,9 @@ export const useNotificationCenterStore = defineStore('notification-center', () 
   const badgeCount = computed(() => {
     if (bellState.value === 'error') return summary.value.error_event_count || 0
     if (bellState.value === 'warning') return summary.value.warning_event_count || 0
-    if (bellState.value === 'running') return summary.value.active_action_count || 0
+    if (bellState.value === 'running') {
+      return (summary.value.active_action_count || 0) + (summary.value.active_download_count || 0)
+    }
     return 0
   })
   const hasActiveSignal = computed(() => bellState.value === 'error' || bellState.value === 'warning' || bellState.value === 'running')
@@ -73,6 +84,7 @@ export const useNotificationCenterStore = defineStore('notification-center', () 
       const data = await getEventCenter()
       summary.value = data?.summary || { ...EMPTY_SUMMARY }
       activeActions.value = data?.active_actions || []
+      activeDownloads.value = data?.active_downloads || []
       events.value = data?.events || []
       if (summary.value.bell_state === 'idle') {
         activityBoostUntil.value = 0
@@ -111,6 +123,7 @@ export const useNotificationCenterStore = defineStore('notification-center', () 
     visible,
     summary,
     activeActions,
+    activeDownloads,
     events,
     centerItems,
     loading,


### PR DESCRIPTION
## Summary
- supersede older unread alerts when the same indexer site emits a newer unhealthy notification
- show pending, downloading, and paused download tasks in the notification center
- include active downloads in the running bell state, badge, and localized UI

## Validation
- `./aethera.sh test-backend tests/test_event_center.py tests/test_indexer_site_health_alerts.py` (26 passed)
- `./scripts/review_with_gates.sh` (backend quality and 243 selected tests; frontend quality, lint, and build)