### PR TITLE
Prefer season posters in scoped media details

### DIFF
--- a/backend/app/services/application/views/media_detail/poster.py
+++ b/backend/app/services/application/views/media_detail/poster.py
@@ -1,0 +1,14 @@
+from app.schemas.domain.media import MediaFullInfo
+from app.schemas.domain.media_types import MediaType
+
+
+def apply_media_detail_poster(media: MediaFullInfo, season_number: int | None) -> MediaFullInfo:
+    if media.media_type != MediaType.tv or season_number is None or season_number <= 0:
+        return media
+    selected_season = next(
+        (season for season in media.seasons if season.season_number == int(season_number)),
+        None,
+    )
+    if not selected_season or not selected_season.poster_path:
+        return media
+    return media.model_copy(update={"poster_path": selected_season.poster_path})

--- a/backend/app/services/application/views/media_detail/service.py
+++ b/backend/app/services/application/views/media_detail/service.py
@@ -4,6 +4,7 @@ from app.schemas.domain.media import MediaFullInfo
 from app.schemas.domain.media_source import MediaSourceLookup, MediaSourceName
 from app.schemas.domain.media_types import MediaType
 from app.services.domain.media import media_service
+from app.services.application.views.media_detail.poster import apply_media_detail_poster
 
 
 class MediaDetailApplicationService:
@@ -58,7 +59,9 @@ class MediaDetailApplicationService:
             media = None
         if not media:
             raise MediaNotFoundException()
-        media = media_service.apply_season_context(media, requested_season or season_number or self._default_detail_season(media))
+        effective_season = requested_season or season_number or self._default_detail_season(media)
+        media = media_service.apply_season_context(media, effective_season)
+        media = apply_media_detail_poster(media, effective_season)
         media.viewed = media_service.is_viewed_media(media.media_id)
         return media
 

--- a/backend/app/services/application/views/media_detail_page/service.py
+++ b/backend/app/services/application/views/media_detail_page/service.py
@@ -19,6 +19,7 @@ from app.schemas.media_id import MediaID, Provider
 from app.schemas.runtime.media_detail_page import MediaDetailPageResponse, MediaDetailPageTabData
 from app.services.application.commands.service import command_service
 from app.services.application.views.media_detail_overview import media_detail_overview_service
+from app.services.application.views.media_detail.poster import apply_media_detail_poster
 from app.services.application.views.task import task_view_service
 from app.services.domain.library.service import MediaLibrarySnapshot, library_service
 from app.services.domain.media import media_service
@@ -216,6 +217,7 @@ class MediaDetailPageApplicationService:
                 raise MediaNotFoundException()
             resolved_season = self._default_detail_season(media, target.source_year)
             media = media_service.apply_season_context(media, resolved_season)
+            media = apply_media_detail_poster(media, resolved_season)
             media.viewed = media_service.is_viewed_media(media.media_id)
             return _LoadedMedia(media=media, cache_mode=cache_mode)
         media, cache_mode = await media_service.info_with_cache_status(
@@ -226,7 +228,9 @@ class MediaDetailPageApplicationService:
         )
         if not media:
             raise MediaNotFoundException()
-        media = media_service.apply_season_context(media, target.season_number or self._default_detail_season(media))
+        effective_season = target.season_number or self._default_detail_season(media)
+        media = media_service.apply_season_context(media, effective_season)
+        media = apply_media_detail_poster(media, effective_season)
         if target.source == MediaSourceName.douban and target.source_id:
             douban_vote_average = media.douban_vote_average
             douban_rating_count = media.douban_rating_count

--- a/backend/app/services/domain/media/profile/read_model.py
+++ b/backend/app/services/domain/media/profile/read_model.py
@@ -85,7 +85,7 @@ class MediaProfileReadModel:
             overview=(selected_scope.douban_overview if selected_scope else None) or profile.overview,
             douban_overview=selected_scope.douban_overview if selected_scope else None,
             genres=profile.genres,
-            poster_path=(selected_scope.poster_path if selected_scope else None) or profile.poster_path,
+            poster_path=profile.poster_path,
             backdrop_path=profile.backdrop_path,
             logo_path=profile.logo_path,
             actors=profile.actors,

--- a/backend/app/services/domain/media/profile/read_model.py
+++ b/backend/app/services/domain/media/profile/read_model.py
@@ -85,7 +85,7 @@ class MediaProfileReadModel:
             overview=(selected_scope.douban_overview if selected_scope else None) or profile.overview,
             douban_overview=selected_scope.douban_overview if selected_scope else None,
             genres=profile.genres,
-            poster_path=profile.poster_path,
+            poster_path=(selected_scope.poster_path if selected_scope else None) or profile.poster_path,
             backdrop_path=profile.backdrop_path,
             logo_path=profile.logo_path,
             actors=profile.actors,

--- a/backend/tests/test_media_profile_service_simple_info.py
+++ b/backend/tests/test_media_profile_service_simple_info.py
@@ -92,6 +92,7 @@ def _scope(
     media_id: MediaID,
     season_number: int,
     *,
+    poster_path: str | None = None,
     episode_count: int | None = None,
     episode_count_override: int | None = None,
     douban_id: str | None = None,
@@ -108,6 +109,7 @@ def _scope(
         media_id=media_id,
         season_number=season_number,
         media_type=media_id.media_type,
+        poster_path=poster_path,
         episode_count=episode_count,
         episode_count_override=episode_count_override,
         douban_id=douban_id,
@@ -230,6 +232,27 @@ def test_profile_read_model_prefers_scoped_douban_overview_with_tmdb_fallback():
     assert douban_media.overview == "Douban overview"
     assert douban_media.douban_overview == "Douban overview"
     assert fallback_media.overview == "TMDB overview"
+
+
+def test_profile_read_model_prefers_scoped_poster_with_profile_fallback():
+    service = MediaProfileService(provider_service=None, schedule_service=MediaScheduleService())
+    media_id = MediaID.parse("tmdb:tv:312823")
+    profile = _ready_profile(media_id)
+    profile.poster_path = "/series-poster.jpg"
+
+    scoped_media = service.read_model.to_full(
+        media_id,
+        profile,
+        selected_scope=_scope(media_id, 4, poster_path="/season-poster.jpg"),
+    )
+    fallback_media = service.read_model.to_full(
+        media_id,
+        profile,
+        selected_scope=_scope(media_id, 3),
+    )
+
+    assert scoped_media.poster_path == "/season-poster.jpg"
+    assert fallback_media.poster_path == "/series-poster.jpg"
 
 
 def test_build_profile_from_media_stores_only_current_tv_season_airings():

--- a/backend/tests/test_media_profile_service_simple_info.py
+++ b/backend/tests/test_media_profile_service_simple_info.py
@@ -234,7 +234,7 @@ def test_profile_read_model_prefers_scoped_douban_overview_with_tmdb_fallback():
     assert fallback_media.overview == "TMDB overview"
 
 
-def test_profile_read_model_prefers_scoped_poster_with_profile_fallback():
+def test_profile_read_model_keeps_profile_poster_for_scoped_consumers():
     service = MediaProfileService(provider_service=None, schedule_service=MediaScheduleService())
     media_id = MediaID.parse("tmdb:tv:312823")
     profile = _ready_profile(media_id)
@@ -245,14 +245,8 @@ def test_profile_read_model_prefers_scoped_poster_with_profile_fallback():
         profile,
         selected_scope=_scope(media_id, 4, poster_path="/season-poster.jpg"),
     )
-    fallback_media = service.read_model.to_full(
-        media_id,
-        profile,
-        selected_scope=_scope(media_id, 3),
-    )
 
-    assert scoped_media.poster_path == "/season-poster.jpg"
-    assert fallback_media.poster_path == "/series-poster.jpg"
+    assert scoped_media.poster_path == "/series-poster.jpg"
 
 
 def test_build_profile_from_media_stores_only_current_tv_season_airings():

--- a/backend/tests/test_media_source_canonical.py
+++ b/backend/tests/test_media_source_canonical.py
@@ -18,10 +18,38 @@ from app.services.domain.media.provider.normalization import build_tmdb_media_in
 from app.services.domain.media.mapping import MediaExternalMappingService, TMDBMappingAttachResult
 from app.services.application.workflows.discover import DiscoverService
 from app.services.application.views.media_detail_page.service import MediaDetailPageApplicationService, _ResolvedDetailTarget
+from app.services.application.views.media_detail.poster import apply_media_detail_poster
 from app.utils import build_loose_tmdb_search_title, build_tmdb_search_title
 
 
 pytestmark = [pytest.mark.drift, pytest.mark.health]
+
+
+def test_media_detail_poster_prefers_selected_tv_season_only():
+    tv_media = MediaFullInfo(
+        media_id=MediaID.parse("tmdb:tv:312823"),
+        title="Example Show",
+        year=2026,
+        media_type=MediaType.tv,
+        poster_path="/series-poster.jpg",
+        seasons=[
+            MediaSeasonInfo(season_number=3),
+            MediaSeasonInfo(season_number=4, poster_path="/season-poster.jpg"),
+        ],
+        primary_metadata_source="tmdb",
+    )
+    movie_media = MediaFullInfo(
+        media_id=MediaID.parse("tmdb:movie:312823"),
+        title="Example Movie",
+        year=2026,
+        media_type=MediaType.movie,
+        poster_path="/movie-poster.jpg",
+        primary_metadata_source="tmdb",
+    )
+
+    assert apply_media_detail_poster(tv_media, 4).poster_path == "/season-poster.jpg"
+    assert apply_media_detail_poster(tv_media, 3).poster_path == "/series-poster.jpg"
+    assert apply_media_detail_poster(movie_media, 4).poster_path == "/movie-poster.jpg"
 
 
 class FakeDoubanClient:


### PR DESCRIPTION
## Summary

- prefer the selected TV season poster in scoped media details
- fall back to the series poster when the selected season has no poster
- add regression coverage for both paths

## Tests

- `./scripts/review_with_gates.sh`
- `./aethera.sh test-backend tests/test_media_profile_service_simple_info.py`

## Runtime verification

- restarted the backend service
- confirmed `tmdb:tv:312823`, season 4 returns `/2irVsWQypRDLrykgrTJeuKH7mR8.jpg`