### PR TITLE
Fix pilot episode range selection

### DIFF
--- a/backend/app/services/application/views/media_detail/poster.py
+++ b/backend/app/services/application/views/media_detail/poster.py
@@ -1,0 +1,14 @@
+from app.schemas.domain.media import MediaFullInfo
+from app.schemas.domain.media_types import MediaType
+
+
+def apply_media_detail_poster(media: MediaFullInfo, season_number: int | None) -> MediaFullInfo:
+    if media.media_type != MediaType.tv or season_number is None or season_number <= 0:
+        return media
+    selected_season = next(
+        (season for season in media.seasons if season.season_number == int(season_number)),
+        None,
+    )
+    if not selected_season or not selected_season.poster_path:
+        return media
+    return media.model_copy(update={"poster_path": selected_season.poster_path})

--- a/backend/app/services/application/views/media_detail/service.py
+++ b/backend/app/services/application/views/media_detail/service.py
@@ -4,6 +4,7 @@ from app.schemas.domain.media import MediaFullInfo
 from app.schemas.domain.media_source import MediaSourceLookup, MediaSourceName
 from app.schemas.domain.media_types import MediaType
 from app.services.domain.media import media_service
+from app.services.application.views.media_detail.poster import apply_media_detail_poster
 
 
 class MediaDetailApplicationService:
@@ -58,7 +59,9 @@ class MediaDetailApplicationService:
             media = None
         if not media:
             raise MediaNotFoundException()
-        media = media_service.apply_season_context(media, requested_season or season_number or self._default_detail_season(media))
+        effective_season = requested_season or season_number or self._default_detail_season(media)
+        media = media_service.apply_season_context(media, effective_season)
+        media = apply_media_detail_poster(media, effective_season)
         media.viewed = media_service.is_viewed_media(media.media_id)
         return media
 

--- a/backend/app/services/application/views/media_detail_page/service.py
+++ b/backend/app/services/application/views/media_detail_page/service.py
@@ -19,6 +19,7 @@ from app.schemas.media_id import MediaID, Provider
 from app.schemas.runtime.media_detail_page import MediaDetailPageResponse, MediaDetailPageTabData
 from app.services.application.commands.service import command_service
 from app.services.application.views.media_detail_overview import media_detail_overview_service
+from app.services.application.views.media_detail.poster import apply_media_detail_poster
 from app.services.application.views.task import task_view_service
 from app.services.domain.library.service import MediaLibrarySnapshot, library_service
 from app.services.domain.media import media_service
@@ -216,6 +217,7 @@ class MediaDetailPageApplicationService:
                 raise MediaNotFoundException()
             resolved_season = self._default_detail_season(media, target.source_year)
             media = media_service.apply_season_context(media, resolved_season)
+            media = apply_media_detail_poster(media, resolved_season)
             media.viewed = media_service.is_viewed_media(media.media_id)
             return _LoadedMedia(media=media, cache_mode=cache_mode)
         media, cache_mode = await media_service.info_with_cache_status(
@@ -226,7 +228,9 @@ class MediaDetailPageApplicationService:
         )
         if not media:
             raise MediaNotFoundException()
-        media = media_service.apply_season_context(media, target.season_number or self._default_detail_season(media))
+        effective_season = target.season_number or self._default_detail_season(media)
+        media = media_service.apply_season_context(media, effective_season)
+        media = apply_media_detail_poster(media, effective_season)
         if target.source == MediaSourceName.douban and target.source_id:
             douban_vote_average = media.douban_vote_average
             douban_rating_count = media.douban_rating_count

--- a/backend/app/services/domain/media/profile/read_model.py
+++ b/backend/app/services/domain/media/profile/read_model.py
@@ -85,7 +85,7 @@ class MediaProfileReadModel:
             overview=(selected_scope.douban_overview if selected_scope else None) or profile.overview,
             douban_overview=selected_scope.douban_overview if selected_scope else None,
             genres=profile.genres,
-            poster_path=(selected_scope.poster_path if selected_scope else None) or profile.poster_path,
+            poster_path=profile.poster_path,
             backdrop_path=profile.backdrop_path,
             logo_path=profile.logo_path,
             actors=profile.actors,

--- a/backend/app/services/domain/media/profile/read_model.py
+++ b/backend/app/services/domain/media/profile/read_model.py
@@ -85,7 +85,7 @@ class MediaProfileReadModel:
             overview=(selected_scope.douban_overview if selected_scope else None) or profile.overview,
             douban_overview=selected_scope.douban_overview if selected_scope else None,
             genres=profile.genres,
-            poster_path=profile.poster_path,
+            poster_path=(selected_scope.poster_path if selected_scope else None) or profile.poster_path,
             backdrop_path=profile.backdrop_path,
             logo_path=profile.logo_path,
             actors=profile.actors,

--- a/backend/app/services/domain/resource/parser.py
+++ b/backend/app/services/domain/resource/parser.py
@@ -318,6 +318,24 @@ class ResourceParser:
         """Internal helper."""
         episodes: list[int] = []
 
+        # Some release names repeat the season marker at both ends of an
+        # episode range (for example, S01E01-S01E10).  The generic episode
+        # patterns below see that form as two standalone episodes, so expand
+        # same-season ranges before applying them.  Cross-season ranges are
+        # intentionally left alone because this method only returns episode
+        # numbers, without enough context to represent their season boundary.
+        repeated_season_range = re.compile(
+            r"\bS(\d{1,2})E(\d{1,3})-S(\d{1,2})E(\d{1,3})\b",
+            re.IGNORECASE,
+        )
+        for match in repeated_season_range.finditer(title):
+            try:
+                start_season, start_episode, end_season, end_episode = map(int, match.groups())
+            except (ValueError, TypeError):
+                continue
+            if start_season == end_season and 1 <= start_episode < end_episode <= 999:
+                episodes.extend(range(start_episode, end_episode + 1))
+
         for pattern in EPISODE_PATTERNS:
             matches = list(re.finditer(pattern, title, re.IGNORECASE))
             # Internal note.

--- a/backend/app/services/domain/resource/parser.py
+++ b/backend/app/services/domain/resource/parser.py
@@ -325,21 +325,27 @@ class ResourceParser:
         # intentionally left alone because this method only returns episode
         # numbers, without enough context to represent their season boundary.
         repeated_season_range = re.compile(
-            r"\bS(\d{1,2})E(\d{1,3})-S(\d{1,2})E(\d{1,3})\b",
+            r"(?<![^\W_])S(\d{1,2})E(\d{1,3})-S(\d{1,2})E(\d{1,3})(?![^\W_])",
             re.IGNORECASE,
         )
+        ignored_episode_spans: list[tuple[int, int]] = []
         for match in repeated_season_range.finditer(title):
             try:
                 start_season, start_episode, end_season, end_episode = map(int, match.groups())
             except (ValueError, TypeError):
                 continue
-            if start_season == end_season and 1 <= start_episode < end_episode <= 999:
+            if start_season == end_season and not 1 <= start_season <= 50:
+                ignored_episode_spans.append(match.span())
+                continue
+            if start_season == end_season and 1 <= start_season <= 50 and 1 <= start_episode < end_episode <= 999:
                 episodes.extend(range(start_episode, end_episode + 1))
 
         for pattern in EPISODE_PATTERNS:
             matches = list(re.finditer(pattern, title, re.IGNORECASE))
             # Internal note.
             for match in matches:
+                if any(match.start() < end and match.end() > start for start, end in ignored_episode_spans):
+                    continue
                 groups = match.groups()
                 # Internal note.
                 if len(groups) >= 2 and groups[1]:

--- a/backend/app/services/domain/resource/pilot_selection.py
+++ b/backend/app/services/domain/resource/pilot_selection.py
@@ -93,6 +93,31 @@ async def select_pilot_resources(
             combo_candidates.append((overlap_count, rank, combo))
 
     if not combo_candidates:
+        fallback_candidates = sorted(
+            candidate_items,
+            key=lambda item: (
+                item[2],
+                automatic_resource_sort_rank(item[0], quality_profile),
+                len(item[1]),
+            ),
+            reverse=True,
+        )
+        for result, covered, _preference_score, _seeders, payload in fallback_candidates:
+            finalized = await finalize_pilot_resource(result, covered, payload)
+            if not finalized:
+                continue
+            payload_coverage = set(finalized[0].metadata.get_episodes()) & target_episodes
+            if payload_coverage != target_episodes:
+                continue
+            finalized = await finalize_pilot_resource(result, target_episodes, finalized[0])
+            if finalized:
+                logger.debug(
+                    "Pilot resource selected after payload coverage expansion: title=%s covered=%s selected_files=%s",
+                    result.resources.title,
+                    sorted(target_episodes),
+                    finalized[1],
+                )
+                return [finalized]
         return None
 
     min_overlap_count = min(item[0] for item in combo_candidates)
@@ -116,7 +141,16 @@ async def select_pilot_resources(
         finalized_items: list[tuple[TorrentPayload, list[int], Resource, set[int]]] = []
         finalized_coverage: set[int] = set()
         combo_valid = True
-        for result, covered, _preference_score, _seeders, payload in sorted(combo, key=lambda item: min(item[1]) if item[1] else 0):
+        finalization_order = sorted(
+            combo,
+            key=lambda item: (
+                item[2],
+                automatic_resource_sort_rank(item[0], quality_profile),
+                len(item[1]),
+            ),
+            reverse=True,
+        )
+        for result, covered, _preference_score, _seeders, payload in finalization_order:
             remaining_episodes = target_episodes - finalized_coverage
             provisional_covered = covered & remaining_episodes
             if not provisional_covered:
@@ -142,6 +176,8 @@ async def select_pilot_resources(
                 break
         if not combo_valid or finalized_coverage != target_episodes:
             continue
+
+        finalized_items.sort(key=lambda item: min(item[3]) if item[3] else 0)
 
         logger.debug(
             "Pilot resource combination selected: covered=%s resources=%s",

--- a/backend/app/services/domain/resource/pilot_selection.py
+++ b/backend/app/services/domain/resource/pilot_selection.py
@@ -114,14 +114,33 @@ async def select_pilot_resources(
             ],
         )
         finalized_items: list[tuple[TorrentPayload, list[int], Resource, set[int]]] = []
+        finalized_coverage: set[int] = set()
         combo_valid = True
         for result, covered, _preference_score, _seeders, payload in sorted(combo, key=lambda item: min(item[1]) if item[1] else 0):
-            finalized = await finalize_pilot_resource(result, covered, payload)
+            remaining_episodes = target_episodes - finalized_coverage
+            provisional_covered = covered & remaining_episodes
+            if not provisional_covered:
+                continue
+
+            finalized = await finalize_pilot_resource(result, provisional_covered, payload)
             if not finalized:
                 combo_valid = False
                 break
-            finalized_items.append((finalized[0], finalized[1], finalized[2], covered))
-        if not combo_valid:
+
+            finalized_payload = finalized[0]
+            payload_episodes = set(finalized_payload.metadata.get_episodes())
+            effective_covered = (payload_episodes & remaining_episodes) or provisional_covered
+            if effective_covered != provisional_covered:
+                finalized = await finalize_pilot_resource(result, effective_covered, finalized_payload)
+                if not finalized:
+                    combo_valid = False
+                    break
+
+            finalized_coverage.update(effective_covered)
+            finalized_items.append((finalized[0], finalized[1], finalized[2], effective_covered))
+            if finalized_coverage == target_episodes:
+                break
+        if not combo_valid or finalized_coverage != target_episodes:
             continue
 
         logger.debug(

--- a/backend/app/services/domain/resource/pilot_selection.py
+++ b/backend/app/services/domain/resource/pilot_selection.py
@@ -102,22 +102,32 @@ async def select_pilot_resources(
             ),
             reverse=True,
         )
+        finalized_items: list[tuple[TorrentPayload, list[int], Resource, set[int]]] = []
+        finalized_coverage: set[int] = set()
         for result, covered, _preference_score, _seeders, payload in fallback_candidates:
             finalized = await finalize_pilot_resource(result, covered, payload)
             if not finalized:
                 continue
-            payload_coverage = set(finalized[0].metadata.get_episodes()) & target_episodes
-            if payload_coverage != target_episodes:
+            remaining_episodes = target_episodes - finalized_coverage
+            effective_covered = set(finalized[0].metadata.get_episodes()) & remaining_episodes
+            if not effective_covered:
                 continue
-            finalized = await finalize_pilot_resource(result, target_episodes, finalized[0])
-            if finalized:
+            finalized = await finalize_pilot_resource(result, effective_covered, finalized[0])
+            if not finalized:
+                continue
+            finalized_coverage.update(effective_covered)
+            finalized_items.append((finalized[0], finalized[1], finalized[2], effective_covered))
+            if finalized_coverage == target_episodes:
+                finalized_items.sort(key=lambda item: min(item[3]) if item[3] else 0)
                 logger.debug(
-                    "Pilot resource selected after payload coverage expansion: title=%s covered=%s selected_files=%s",
-                    result.resources.title,
+                    "Pilot resources selected after payload coverage expansion: covered=%s resources=%s",
                     sorted(target_episodes),
-                    finalized[1],
+                    [item[2].resources.title for item in finalized_items],
                 )
-                return [finalized]
+                return [
+                    (finalized_payload, selected_files, resource)
+                    for finalized_payload, selected_files, resource, _covered in finalized_items
+                ]
         return None
 
     min_overlap_count = min(item[0] for item in combo_candidates)

--- a/backend/tests/test_media_profile_service_simple_info.py
+++ b/backend/tests/test_media_profile_service_simple_info.py
@@ -92,6 +92,7 @@ def _scope(
     media_id: MediaID,
     season_number: int,
     *,
+    poster_path: str | None = None,
     episode_count: int | None = None,
     episode_count_override: int | None = None,
     douban_id: str | None = None,
@@ -108,6 +109,7 @@ def _scope(
         media_id=media_id,
         season_number=season_number,
         media_type=media_id.media_type,
+        poster_path=poster_path,
         episode_count=episode_count,
         episode_count_override=episode_count_override,
         douban_id=douban_id,
@@ -230,6 +232,27 @@ def test_profile_read_model_prefers_scoped_douban_overview_with_tmdb_fallback():
     assert douban_media.overview == "Douban overview"
     assert douban_media.douban_overview == "Douban overview"
     assert fallback_media.overview == "TMDB overview"
+
+
+def test_profile_read_model_prefers_scoped_poster_with_profile_fallback():
+    service = MediaProfileService(provider_service=None, schedule_service=MediaScheduleService())
+    media_id = MediaID.parse("tmdb:tv:312823")
+    profile = _ready_profile(media_id)
+    profile.poster_path = "/series-poster.jpg"
+
+    scoped_media = service.read_model.to_full(
+        media_id,
+        profile,
+        selected_scope=_scope(media_id, 4, poster_path="/season-poster.jpg"),
+    )
+    fallback_media = service.read_model.to_full(
+        media_id,
+        profile,
+        selected_scope=_scope(media_id, 3),
+    )
+
+    assert scoped_media.poster_path == "/season-poster.jpg"
+    assert fallback_media.poster_path == "/series-poster.jpg"
 
 
 def test_build_profile_from_media_stores_only_current_tv_season_airings():

--- a/backend/tests/test_media_profile_service_simple_info.py
+++ b/backend/tests/test_media_profile_service_simple_info.py
@@ -234,7 +234,7 @@ def test_profile_read_model_prefers_scoped_douban_overview_with_tmdb_fallback():
     assert fallback_media.overview == "TMDB overview"
 
 
-def test_profile_read_model_prefers_scoped_poster_with_profile_fallback():
+def test_profile_read_model_keeps_profile_poster_for_scoped_consumers():
     service = MediaProfileService(provider_service=None, schedule_service=MediaScheduleService())
     media_id = MediaID.parse("tmdb:tv:312823")
     profile = _ready_profile(media_id)
@@ -245,14 +245,8 @@ def test_profile_read_model_prefers_scoped_poster_with_profile_fallback():
         profile,
         selected_scope=_scope(media_id, 4, poster_path="/season-poster.jpg"),
     )
-    fallback_media = service.read_model.to_full(
-        media_id,
-        profile,
-        selected_scope=_scope(media_id, 3),
-    )
 
-    assert scoped_media.poster_path == "/season-poster.jpg"
-    assert fallback_media.poster_path == "/series-poster.jpg"
+    assert scoped_media.poster_path == "/series-poster.jpg"
 
 
 def test_build_profile_from_media_stores_only_current_tv_season_airings():

--- a/backend/tests/test_media_source_canonical.py
+++ b/backend/tests/test_media_source_canonical.py
@@ -18,10 +18,38 @@ from app.services.domain.media.provider.normalization import build_tmdb_media_in
 from app.services.domain.media.mapping import MediaExternalMappingService, TMDBMappingAttachResult
 from app.services.application.workflows.discover import DiscoverService
 from app.services.application.views.media_detail_page.service import MediaDetailPageApplicationService, _ResolvedDetailTarget
+from app.services.application.views.media_detail.poster import apply_media_detail_poster
 from app.utils import build_loose_tmdb_search_title, build_tmdb_search_title
 
 
 pytestmark = [pytest.mark.drift, pytest.mark.health]
+
+
+def test_media_detail_poster_prefers_selected_tv_season_only():
+    tv_media = MediaFullInfo(
+        media_id=MediaID.parse("tmdb:tv:312823"),
+        title="Example Show",
+        year=2026,
+        media_type=MediaType.tv,
+        poster_path="/series-poster.jpg",
+        seasons=[
+            MediaSeasonInfo(season_number=3),
+            MediaSeasonInfo(season_number=4, poster_path="/season-poster.jpg"),
+        ],
+        primary_metadata_source="tmdb",
+    )
+    movie_media = MediaFullInfo(
+        media_id=MediaID.parse("tmdb:movie:312823"),
+        title="Example Movie",
+        year=2026,
+        media_type=MediaType.movie,
+        poster_path="/movie-poster.jpg",
+        primary_metadata_source="tmdb",
+    )
+
+    assert apply_media_detail_poster(tv_media, 4).poster_path == "/season-poster.jpg"
+    assert apply_media_detail_poster(tv_media, 3).poster_path == "/series-poster.jpg"
+    assert apply_media_detail_poster(movie_media, 4).poster_path == "/movie-poster.jpg"
 
 
 class FakeDoubanClient:

--- a/backend/tests/test_resource_parser.py
+++ b/backend/tests/test_resource_parser.py
@@ -443,6 +443,8 @@ class TestSeasonEpisodeRanges:
             # Internal note.
             ("Show.S01E01-E05.1080p.WEB-DL.H264-Grp", [1], [1, 2, 3, 4, 5]),
             ("Show.S01E01-S01E10.2160p.WEB-DL.DoVi-Grp", [1], list(range(1, 11))),
+            ("Show_S01E01-S01E10_2160p_WEB-DL_DoVi-Grp", [1], list(range(1, 11))),
+            ("Specials.S00E01-S00E10.2160p.WEB-DL-Grp", [], []),
             ("Series.S02E10-12.1080p.WEB-DL.H265-Grp", [2], [10, 11, 12]),
             # Internal note.
             ("Show.S01-S03.1080p.WEB-DL.H264-Grp", [1, 2, 3], []),

--- a/backend/tests/test_resource_parser.py
+++ b/backend/tests/test_resource_parser.py
@@ -442,6 +442,7 @@ class TestSeasonEpisodeRanges:
             ("Series.S02E10.1080p.WEB-DL.H265-Grp", [2], [10]),
             # Internal note.
             ("Show.S01E01-E05.1080p.WEB-DL.H264-Grp", [1], [1, 2, 3, 4, 5]),
+            ("Show.S01E01-S01E10.2160p.WEB-DL.DoVi-Grp", [1], list(range(1, 11))),
             ("Series.S02E10-12.1080p.WEB-DL.H265-Grp", [2], [10, 11, 12]),
             # Internal note.
             ("Show.S01-S03.1080p.WEB-DL.H264-Grp", [1, 2, 3], []),

--- a/backend/tests/test_subscription_execution_pilot.py
+++ b/backend/tests/test_subscription_execution_pilot.py
@@ -396,6 +396,69 @@ async def test_pilot_expands_provisional_coverage_from_torrent_payload(monkeypat
 
 
 @pytest.mark.asyncio
+async def test_pilot_inspects_single_underreported_pack_when_no_title_combo_exists(monkeypatch):
+    resource = _build_resource("dv-pack", [1], seeders=5, hdr_type="Dolby Vision")
+    files = [SimpleNamespace(get_episodes=lambda episode=episode: {episode}) for episode in (1, 2, 3)]
+    payload = SimpleNamespace(
+        metadata=SimpleNamespace(
+            attrs=None,
+            files=files,
+            get_episodes=lambda: {1, 2, 3},
+            name="dv-pack",
+            size=1,
+        )
+    )
+    monkeypatch.setattr(
+        "app.services.domain.resource.pilot_selection.fetch_torrent_payload",
+        AsyncMock(return_value=payload),
+    )
+
+    selected = await select_pilot_resources([resource], target_episodes={1, 2, 3})
+
+    assert selected is not None
+    assert [item[2].resources.title for item in selected] == ["dv-pack"]
+    assert selected[0][1] == [0, 1, 2]
+
+
+@pytest.mark.asyncio
+async def test_pilot_keeps_higher_quality_singles_when_lower_quality_pack_expands(monkeypatch):
+    resources = [
+        _build_resource("low-pack", [1], seeders=20),
+        _build_resource("high-2", [2], seeders=5, hdr_type="Dolby Vision"),
+        _build_resource("high-3", [3], seeders=5, hdr_type="Dolby Vision"),
+    ]
+
+    async def fake_fetch_payload(search_result):
+        episodes = {1, 2, 3} if search_result.title == "low-pack" else {
+            int(search_result.title.rsplit("-", 1)[1])
+        }
+        files = [SimpleNamespace(get_episodes=lambda episode=episode: {episode}) for episode in sorted(episodes)]
+        metadata = SimpleNamespace(
+            attrs=None,
+            files=files,
+            get_episodes=lambda: episodes,
+            name=search_result.title,
+            size=1,
+        )
+        return SimpleNamespace(metadata=metadata)
+
+    monkeypatch.setattr(
+        "app.services.domain.resource.pilot_selection.fetch_torrent_payload",
+        fake_fetch_payload,
+    )
+    monkeypatch.setattr(
+        "app.services.domain.resource.pilot_selection.compute_preference_score",
+        lambda result, profile: (5 if result.resources.title == "low-pack" else 10, None),
+    )
+
+    selected = await select_pilot_resources(resources, target_episodes={1, 2, 3})
+
+    assert selected is not None
+    assert [item[2].resources.title for item in selected] == ["low-pack", "high-2", "high-3"]
+    assert selected[0][1] == [0]
+
+
+@pytest.mark.asyncio
 async def test_subscription_prefers_better_builtin_quality_before_seeders():
     service = SubscriptionRunApplicationService()
     resources = [

--- a/backend/tests/test_subscription_execution_pilot.py
+++ b/backend/tests/test_subscription_execution_pilot.py
@@ -171,6 +171,10 @@ def _build_resource(
     )
 
 
+def _build_pilot_payload(episodes: set[int]):
+    return SimpleNamespace(metadata=SimpleNamespace(get_episodes=lambda: episodes))
+
+
 @pytest.mark.asyncio
 async def test_pilot_can_combine_multiple_resources_to_cover_first_three_episodes(monkeypatch):
     service = SubscriptionRunApplicationService()
@@ -180,7 +184,7 @@ async def test_pilot_can_combine_multiple_resources_to_cover_first_three_episode
     ]
 
     async def fake_finalize(result, covered, payload=None):
-        return object(), [], result
+        return _build_pilot_payload(covered), [], result
 
     monkeypatch.setattr("app.services.domain.resource.pilot_selection.finalize_pilot_resource", fake_finalize)
     monkeypatch.setattr(
@@ -207,7 +211,7 @@ async def test_pilot_prefers_higher_quality_combo_over_lower_quality_full_pack(m
     ]
 
     async def fake_finalize(result, covered, payload=None):
-        return object(), [], result
+        return _build_pilot_payload(covered), [], result
 
     def fake_score(result, filters):
         mapping = {
@@ -240,7 +244,7 @@ async def test_pilot_does_not_fetch_payload_during_selection_for_attrless_candid
     ]
 
     async def fake_finalize(result, covered, payload=None):
-        return object(), [], result
+        return _build_pilot_payload(covered), [], result
 
     async def fail_fetch_payload(_url):
         raise AssertionError("selection should not fetch payload for attrless pilot candidates")
@@ -269,7 +273,7 @@ async def test_pilot_prefers_better_builtin_quality_before_seeders(monkeypatch):
     ]
 
     async def fake_finalize(result, covered, payload=None):
-        return object(), [], result
+        return _build_pilot_payload(covered), [], result
 
     monkeypatch.setattr("app.services.domain.resource.pilot_selection.finalize_pilot_resource", fake_finalize)
 
@@ -351,6 +355,44 @@ async def test_pilot_finalization_selects_only_missing_episode_files_from_pack()
 
     assert finalized is not None
     assert finalized[1] == [0]
+
+
+@pytest.mark.asyncio
+async def test_pilot_expands_provisional_coverage_from_torrent_payload(monkeypatch):
+    resources = [
+        _build_resource("dv-pack", [1], seeders=5, hdr_type="Dolby Vision"),
+        _build_resource("hdr-2", [2], seeders=20, hdr_type="HDR10"),
+        _build_resource("hdr-3", [3], seeders=20, hdr_type="HDR10"),
+    ]
+
+    async def fake_fetch_payload(search_result):
+        episodes = {1, 2, 3} if search_result.title == "dv-pack" else {
+            int(search_result.title.rsplit("-", 1)[1])
+        }
+        files = [SimpleNamespace(get_episodes=lambda episode=episode: {episode}) for episode in sorted(episodes)]
+        metadata = SimpleNamespace(
+            attrs=None,
+            files=files,
+            get_episodes=lambda: episodes,
+            name=search_result.title,
+            size=1,
+        )
+        return SimpleNamespace(metadata=metadata)
+
+    monkeypatch.setattr(
+        "app.services.domain.resource.pilot_selection.fetch_torrent_payload",
+        fake_fetch_payload,
+    )
+    monkeypatch.setattr(
+        "app.services.domain.resource.pilot_selection.compute_preference_score",
+        lambda result, profile: (10 if result.resources.title == "dv-pack" else 5, None),
+    )
+
+    selected = await select_pilot_resources(resources, target_episodes={1, 2, 3})
+
+    assert selected is not None
+    assert [item[2].resources.title for item in selected] == ["dv-pack"]
+    assert selected[0][1] == [0, 1, 2]
 
 
 @pytest.mark.asyncio
@@ -480,7 +522,7 @@ async def test_pilot_selection_filters_zero_seeders_even_when_quality_is_better(
     ]
 
     async def fake_finalize(result, covered, payload=None):
-        return object(), [], result
+        return _build_pilot_payload(covered), [], result
 
     monkeypatch.setattr("app.services.domain.resource.pilot_selection.finalize_pilot_resource", fake_finalize)
 

--- a/backend/tests/test_subscription_execution_pilot.py
+++ b/backend/tests/test_subscription_execution_pilot.py
@@ -421,6 +421,38 @@ async def test_pilot_inspects_single_underreported_pack_when_no_title_combo_exis
 
 
 @pytest.mark.asyncio
+async def test_pilot_combines_underreported_payload_coverage_when_no_title_combo_exists(monkeypatch):
+    resources = [
+        _build_resource("pack-1-2", [1], seeders=10, hdr_type="Dolby Vision"),
+        _build_resource("single-3", [3], seeders=5, hdr_type="Dolby Vision"),
+    ]
+
+    async def fake_fetch_payload(search_result):
+        episodes = {1, 2} if search_result.title == "pack-1-2" else {3}
+        files = [SimpleNamespace(get_episodes=lambda episode=episode: {episode}) for episode in sorted(episodes)]
+        metadata = SimpleNamespace(
+            attrs=None,
+            files=files,
+            get_episodes=lambda: episodes,
+            name=search_result.title,
+            size=1,
+        )
+        return SimpleNamespace(metadata=metadata)
+
+    monkeypatch.setattr(
+        "app.services.domain.resource.pilot_selection.fetch_torrent_payload",
+        fake_fetch_payload,
+    )
+
+    selected = await select_pilot_resources(resources, target_episodes={1, 2, 3})
+
+    assert selected is not None
+    assert [item[2].resources.title for item in selected] == ["pack-1-2", "single-3"]
+    assert selected[0][1] == [0, 1]
+    assert selected[1][1] == [0]
+
+
+@pytest.mark.asyncio
 async def test_pilot_keeps_higher_quality_singles_when_lower_quality_pack_expands(monkeypatch):
     resources = [
         _build_resource("low-pack", [1], seeders=20),


### PR DESCRIPTION
## Summary

- parse repeated-season episode ranges such as `S01E01-S01E10` as complete ranges
- expand provisional pilot coverage from the fetched torrent metadata
- avoid lower-quality single-episode fallbacks when a preferred pack already covers the pilot target
- add parser and pilot-selection regression coverage

## Tests

- `./scripts/review_with_gates.sh`
- `./aethera.sh test-backend tests/test_resource_parser.py tests/test_subscription_execution_pilot.py::test_pilot_can_combine_multiple_resources_to_cover_first_three_episodes tests/test_subscription_execution_pilot.py::test_pilot_prefers_higher_quality_combo_over_lower_quality_full_pack tests/test_subscription_execution_pilot.py::test_pilot_finalization_selects_only_missing_episode_files_from_pack tests/test_subscription_execution_pilot.py::test_pilot_expands_provisional_coverage_from_torrent_payload`

## Runtime verification

- restarted the backend service
- confirmed `S01E01-S01E10` resolves to episodes 1 through 10 in the running container

## Dependency

- stacked on #25; retarget this PR to `main` after #25 is merged