### PR TITLE
Use the largest TV episode count across providers

### DIFF
--- a/backend/app/services/domain/media/provider/detail.py
+++ b/backend/app/services/domain/media/provider/detail.py
@@ -24,6 +24,7 @@ from app.services.domain.media.provider.normalization import (
     build_tmdb_media_info,
     dedupe_vendors,
     normalize_tmdb_vendors,
+    resolve_largest_episode_count,
     resolve_tmdb_selected_season,
     subject_type,
 )
@@ -52,6 +53,11 @@ class DoubanMediaContext:
         if not self.detail or not self.detail.overview:
             return None
         return self.detail.overview.strip() or None
+
+    @property
+    def episodes_count(self) -> int | None:
+        value = self.detail.episodes_count if self.detail else None
+        return int(value) if value is not None and int(value) > 0 else None
 
 
 class MediaProviderDetail:
@@ -138,9 +144,20 @@ class MediaProviderDetail:
         phase_started_at = time.perf_counter()
         external = details.external_ids or await self.clients.get_tmdb_client().get_external_ids(tmdb_id, subject_type_value)
         resolved_imdb_id = cached_imdb_id or (external.imdb_id if external else None)
-        await self.mapping.set_cached_tmdb_mapping(mid, tmdb_id, resolved_imdb_id, cached_douban_id, cached_season_number, cached_episode_count_override)
-        timings["mapping_write"] = (time.perf_counter() - phase_started_at) * 1000
         douban_context = await douban_context_task
+        effective_episode_count_override = resolve_largest_episode_count(
+            effective_episode_count_override,
+            douban_context.episodes_count if effective_douban_id else None,
+        )
+        await self.mapping.set_cached_tmdb_mapping(
+            mid,
+            tmdb_id,
+            resolved_imdb_id,
+            cached_douban_id,
+            cached_season_number,
+            effective_episode_count_override if effective_douban_id else cached_episode_count_override,
+        )
+        timings["mapping_write"] = (time.perf_counter() - phase_started_at) * 1000
         rating = douban_context.rating
         has_douban_rating = self.has_rating(rating)
         phase_started_at = time.perf_counter()
@@ -176,18 +193,23 @@ class MediaProviderDetail:
         existing_mapping = self.mapping.mapping_repo.find_by_douban_id(lookup.source_id, lookup.media_type.value)
         if existing_mapping and existing_mapping.tmdb_id:
             canonical_media_id = self.mapping.canonical_tmdb_media_id(lookup.media_type, existing_mapping.tmdb_id)
+            douban_context = await self._load_douban_context(
+                {},
+                douban_id=existing_mapping.douban_id or lookup.source_id,
+                media_type=lookup.media_type,
+            )
+            episode_count_override = (
+                resolve_largest_episode_count(existing_mapping.episode_count_override, douban_context.episodes_count)
+                if lookup.media_type == MediaType.tv
+                else None
+            )
             await self.mapping.set_cached_tmdb_mapping(
                 canonical_media_id,
                 existing_mapping.tmdb_id,
                 existing_mapping.imdb_id,
                 existing_mapping.douban_id,
                 existing_mapping.season_number,
-                existing_mapping.episode_count_override,
-            )
-            douban_context = await self._load_douban_context(
-                {},
-                douban_id=existing_mapping.douban_id or lookup.source_id,
-                media_type=lookup.media_type,
+                episode_count_override,
             )
             has_douban_rating = self.has_rating(douban_context.rating)
             return await self.build_tmdb_detail_from_mapping(
@@ -201,7 +223,7 @@ class MediaProviderDetail:
                 rating_source="douban",
                 vendors=douban_context.vendors,
                 douban_overview=douban_context.overview,
-                episode_count_override=existing_mapping.episode_count_override if lookup.media_type == MediaType.tv else None,
+                episode_count_override=episode_count_override,
             )
         try:
             detail = await client.get_subject_detail(lookup.source_id, subject_type_value)
@@ -241,13 +263,14 @@ class MediaProviderDetail:
                 season_number = resolve_tmdb_selected_season(tmdb_details.seasons, season_number, year)
             resolved_imdb_id = imdb_id or (tmdb_details.external_ids.imdb_id if tmdb_details.external_ids else None)
             canonical_media_id = self.mapping.canonical_tmdb_media_id(lookup.media_type, tmdb_id)
+            episode_count_override = detail.episodes_count if lookup.media_type == MediaType.tv else None
             await self.mapping.set_cached_tmdb_mapping(
                 canonical_media_id,
                 tmdb_id,
                 resolved_imdb_id,
                 detail.provider_id,
                 season_number,
-                None,
+                episode_count_override,
             )
         else:
             self.mapping.raise_tmdb_mapping_required(
@@ -277,7 +300,7 @@ class MediaProviderDetail:
                 vendors=dedupe_vendors(merged_vendors),
                 douban_id=detail.provider_id,
                 douban_overview=detail.overview,
-                episode_count_override=None,
+                episode_count_override=episode_count_override,
             ))
 
         raise MediaNotFoundException()

--- a/backend/app/services/domain/media/provider/detail.py
+++ b/backend/app/services/domain/media/provider/detail.py
@@ -144,6 +144,7 @@ class MediaProviderDetail:
         external = details.external_ids or await self.clients.get_tmdb_client().get_external_ids(tmdb_id, subject_type_value)
         resolved_imdb_id = cached_imdb_id or (external.imdb_id if external else None)
         douban_context = await douban_context_task
+        phase_started_at = time.perf_counter()
         await self.mapping.set_cached_tmdb_mapping(
             mid,
             tmdb_id,

--- a/backend/app/services/domain/media/provider/detail.py
+++ b/backend/app/services/domain/media/provider/detail.py
@@ -24,7 +24,6 @@ from app.services.domain.media.provider.normalization import (
     build_tmdb_media_info,
     dedupe_vendors,
     normalize_tmdb_vendors,
-    resolve_largest_episode_count,
     resolve_tmdb_selected_season,
     subject_type,
 )
@@ -145,17 +144,13 @@ class MediaProviderDetail:
         external = details.external_ids or await self.clients.get_tmdb_client().get_external_ids(tmdb_id, subject_type_value)
         resolved_imdb_id = cached_imdb_id or (external.imdb_id if external else None)
         douban_context = await douban_context_task
-        effective_episode_count_override = resolve_largest_episode_count(
-            effective_episode_count_override,
-            douban_context.episodes_count if effective_douban_id else None,
-        )
         await self.mapping.set_cached_tmdb_mapping(
             mid,
             tmdb_id,
             resolved_imdb_id,
             cached_douban_id,
             cached_season_number,
-            effective_episode_count_override if effective_douban_id else cached_episode_count_override,
+            cached_episode_count_override,
         )
         timings["mapping_write"] = (time.perf_counter() - phase_started_at) * 1000
         rating = douban_context.rating
@@ -172,6 +167,7 @@ class MediaProviderDetail:
             vendors=dedupe_vendors(list(douban_context.vendors) + list(tmdb_vendors)),
             douban_id=effective_douban_id,
             douban_overview=douban_context.overview,
+            douban_episode_count=douban_context.episodes_count if effective_douban_id else None,
             episode_count_override=effective_episode_count_override,
         ))
         timings["build_enrich_media"] = (time.perf_counter() - phase_started_at) * 1000
@@ -198,18 +194,13 @@ class MediaProviderDetail:
                 douban_id=existing_mapping.douban_id or lookup.source_id,
                 media_type=lookup.media_type,
             )
-            episode_count_override = (
-                resolve_largest_episode_count(existing_mapping.episode_count_override, douban_context.episodes_count)
-                if lookup.media_type == MediaType.tv
-                else None
-            )
             await self.mapping.set_cached_tmdb_mapping(
                 canonical_media_id,
                 existing_mapping.tmdb_id,
                 existing_mapping.imdb_id,
                 existing_mapping.douban_id,
                 existing_mapping.season_number,
-                episode_count_override,
+                existing_mapping.episode_count_override,
             )
             has_douban_rating = self.has_rating(douban_context.rating)
             return await self.build_tmdb_detail_from_mapping(
@@ -223,7 +214,8 @@ class MediaProviderDetail:
                 rating_source="douban",
                 vendors=douban_context.vendors,
                 douban_overview=douban_context.overview,
-                episode_count_override=episode_count_override,
+                douban_episode_count=douban_context.episodes_count,
+                episode_count_override=existing_mapping.episode_count_override if lookup.media_type == MediaType.tv else None,
             )
         try:
             detail = await client.get_subject_detail(lookup.source_id, subject_type_value)
@@ -263,14 +255,13 @@ class MediaProviderDetail:
                 season_number = resolve_tmdb_selected_season(tmdb_details.seasons, season_number, year)
             resolved_imdb_id = imdb_id or (tmdb_details.external_ids.imdb_id if tmdb_details.external_ids else None)
             canonical_media_id = self.mapping.canonical_tmdb_media_id(lookup.media_type, tmdb_id)
-            episode_count_override = detail.episodes_count if lookup.media_type == MediaType.tv else None
             await self.mapping.set_cached_tmdb_mapping(
                 canonical_media_id,
                 tmdb_id,
                 resolved_imdb_id,
                 detail.provider_id,
                 season_number,
-                episode_count_override,
+                None,
             )
         else:
             self.mapping.raise_tmdb_mapping_required(
@@ -300,7 +291,8 @@ class MediaProviderDetail:
                 vendors=dedupe_vendors(merged_vendors),
                 douban_id=detail.provider_id,
                 douban_overview=detail.overview,
-                episode_count_override=episode_count_override,
+                douban_episode_count=detail.episodes_count,
+                episode_count_override=None,
             ))
 
         raise MediaNotFoundException()
@@ -354,6 +346,7 @@ class MediaProviderDetail:
         rating_source: str,
         vendors,
         douban_overview: str | None = None,
+        douban_episode_count: int | None = None,
         episode_count_override: int | None = None,
     ) -> MediaFullInfo:
         started_at = time.perf_counter()
@@ -385,6 +378,7 @@ class MediaProviderDetail:
             vendors=dedupe_vendors(list(vendors or []) + list(tmdb_vendors or [])),
             douban_id=douban_id,
             douban_overview=douban_overview,
+            douban_episode_count=douban_episode_count,
             episode_count_override=episode_count_override if media_id.media_type == MediaType.tv else None,
         ))
         timings["build_enrich_media"] = (time.perf_counter() - phase_started_at) * 1000

--- a/backend/app/services/domain/media/provider/normalization.py
+++ b/backend/app/services/domain/media/provider/normalization.py
@@ -381,7 +381,7 @@ def build_tmdb_media_info(
         and episode_count_override is not None
         and episode_count_override > 0
     ):
-        selected_episode_count = int(episode_count_override)
+        selected_episode_count = resolve_largest_episode_count(selected_episode_count, episode_count_override)
         seasons = [
             season.model_copy(update={
                 "episode_count_override": selected_episode_count,
@@ -478,7 +478,11 @@ def build_tmdb_media_info(
         release_dates=model_field_list(details, "release_dates"),
         first_air_date=details.first_air_date,
         episodes_count=selected_episode_count if mid.media_type == MediaType.tv else None,
-        episode_count_override=episode_count_override if mid.media_type == MediaType.tv else None,
+        episode_count_override=(
+            selected_episode_count
+            if mid.media_type == MediaType.tv and episode_count_override is not None and episode_count_override > 0
+            else None
+        ),
         seasons_count=details.seasons_count or len(seasons),
         season_number=selected_season if mid.media_type == MediaType.tv else None,
         seasons=seasons,
@@ -493,6 +497,11 @@ def build_tmdb_media_info(
     )
     media._source_networks = list(networks)
     return media
+
+
+def resolve_largest_episode_count(*values: int | None) -> int | None:
+    counts = [int(value) for value in values if value is not None and int(value) > 0]
+    return max(counts) if counts else None
 
 
 def pick_best_tmdb_search_id(title: str, results: list[ProviderSearchItem]) -> int | None:

--- a/backend/app/services/domain/media/provider/normalization.py
+++ b/backend/app/services/domain/media/provider/normalization.py
@@ -341,6 +341,7 @@ def build_tmdb_media_info(
     vendors: list[Vendor],
     douban_id: str | None = None,
     douban_overview: str | None = None,
+    douban_episode_count: int | None = None,
     episode_count_override: int | None = None,
 ) -> MediaFullInfo:
     has_display_rating = vote_average is not None and vote_average > 0
@@ -378,10 +379,24 @@ def build_tmdb_media_info(
     if (
         mid.media_type == MediaType.tv
         and selected_season is not None
+        and douban_episode_count is not None
+        and douban_episode_count > 0
+        and episode_count_override is None
+    ):
+        selected_episode_count = resolve_largest_episode_count(selected_episode_count, douban_episode_count)
+        seasons = [
+            season.model_copy(update={"episode_count": selected_episode_count})
+            if season.season_number == selected_season
+            else season
+            for season in seasons
+        ]
+    if (
+        mid.media_type == MediaType.tv
+        and selected_season is not None
         and episode_count_override is not None
         and episode_count_override > 0
     ):
-        selected_episode_count = resolve_largest_episode_count(selected_episode_count, episode_count_override)
+        selected_episode_count = int(episode_count_override)
         seasons = [
             season.model_copy(update={
                 "episode_count_override": selected_episode_count,
@@ -478,11 +493,7 @@ def build_tmdb_media_info(
         release_dates=model_field_list(details, "release_dates"),
         first_air_date=details.first_air_date,
         episodes_count=selected_episode_count if mid.media_type == MediaType.tv else None,
-        episode_count_override=(
-            selected_episode_count
-            if mid.media_type == MediaType.tv and episode_count_override is not None and episode_count_override > 0
-            else None
-        ),
+        episode_count_override=episode_count_override if mid.media_type == MediaType.tv else None,
         seasons_count=details.seasons_count or len(seasons),
         season_number=selected_season if mid.media_type == MediaType.tv else None,
         seasons=seasons,

--- a/backend/app/services/domain/media/provider/service.py
+++ b/backend/app/services/domain/media/provider/service.py
@@ -15,7 +15,7 @@ from app.services.domain.media.provider.clients import MediaProviderClients
 from app.services.domain.media.provider.detail import MediaProviderDetail
 from app.services.domain.media.provider.discover import MediaProviderDiscover
 from app.services.domain.media.provider.mapping import MediaProviderMapping
-from app.services.domain.media.provider.normalization import resolve_tmdb_selected_season, subject_type
+from app.services.domain.media.provider.normalization import resolve_largest_episode_count, resolve_tmdb_selected_season, subject_type
 from app.services.domain.media.provider.search import search_douban, search_tmdb
 from app.utils import parse_tv_title
 
@@ -120,7 +120,9 @@ class MediaProviderService:
             external.imdb_id if external else None,
             lookup.source_id,
             resolved_season if lookup.media_type == MediaType.tv else None,
-            episode_count_override if lookup.media_type == MediaType.tv else None,
+            resolve_largest_episode_count(episode_count_override, detail.episodes_count)
+            if lookup.media_type == MediaType.tv
+            else None,
         )
         return canonical_media_id
 

--- a/backend/app/services/domain/media/provider/service.py
+++ b/backend/app/services/domain/media/provider/service.py
@@ -15,7 +15,7 @@ from app.services.domain.media.provider.clients import MediaProviderClients
 from app.services.domain.media.provider.detail import MediaProviderDetail
 from app.services.domain.media.provider.discover import MediaProviderDiscover
 from app.services.domain.media.provider.mapping import MediaProviderMapping
-from app.services.domain.media.provider.normalization import resolve_largest_episode_count, resolve_tmdb_selected_season, subject_type
+from app.services.domain.media.provider.normalization import resolve_tmdb_selected_season, subject_type
 from app.services.domain.media.provider.search import search_douban, search_tmdb
 from app.utils import parse_tv_title
 
@@ -120,9 +120,7 @@ class MediaProviderService:
             external.imdb_id if external else None,
             lookup.source_id,
             resolved_season if lookup.media_type == MediaType.tv else None,
-            resolve_largest_episode_count(episode_count_override, detail.episodes_count)
-            if lookup.media_type == MediaType.tv
-            else None,
+            episode_count_override if lookup.media_type == MediaType.tv else None,
         )
         return canonical_media_id
 

--- a/backend/tests/test_media_profile_service_simple_info.py
+++ b/backend/tests/test_media_profile_service_simple_info.py
@@ -998,8 +998,8 @@ async def test_info_from_source_provider_miss_returns_scoped_profile(monkeypatch
         tmdb_id=278894,
         douban_id="36809858",
         season_number=2,
-        episodes_count=10,
-        seasons=[MediaSeasonInfo(season_number=2, episode_count=10)],
+        episodes_count=23,
+        seasons=[MediaSeasonInfo(season_number=2, episode_count=23)],
         schedule=MediaScheduleSummary(
             media_type=MediaType.tv,
             aired_episode_count=4,
@@ -1058,7 +1058,10 @@ async def test_info_from_source_provider_miss_returns_scoped_profile(monkeypatch
 
     assert media is not None
     assert media.seasons[0].douban_id == "36809858"
-    assert media.seasons[0].episode_count == 10
+    assert media.episodes_count == 23
+    assert media.episode_count_override is None
+    assert media.seasons[0].episode_count == 23
+    assert saved_mapping["episode_count_override"] is None
     assert media.aired_episode_count == 4
     assert media.latest_aired_episode == EpisodeInfo(season_number=2, episode_number=4, air_date="2026-05-01")
     assert [(item.season_number, item.episode_number) for item in media.airings] == [(2, 4)]

--- a/backend/tests/test_media_provider_service_tmdb_source.py
+++ b/backend/tests/test_media_provider_service_tmdb_source.py
@@ -190,14 +190,14 @@ async def test_tmdb_tv_info_uses_larger_douban_episode_count_for_selected_season
 
     assert media is not None
     assert media.episodes_count == 23
-    assert media.episode_count_override == 23
+    assert media.episode_count_override is None
     set_cached.assert_awaited_once_with(
         MediaID.parse("tmdb:tv:280133"),
         280133,
         "tt0499549",
         "35653123",
         1,
-        23,
+        None,
     )
 
 

--- a/backend/tests/test_media_provider_service_tmdb_source.py
+++ b/backend/tests/test_media_provider_service_tmdb_source.py
@@ -81,6 +81,7 @@ async def test_tmdb_movie_info_uses_douban_rating_when_douban_id_is_cached(monke
             overview="Douban plot",
             rating=ProviderRating(value=9.2, count=4567),
             vendors=[],
+            episodes_count=None,
         )),
     )
     monkeypatch.setattr(service.clients, "get_douban_client", lambda: douban_client)
@@ -158,6 +159,49 @@ async def test_tmdb_tv_info_is_marked_as_tmdb_primary_source(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_tmdb_tv_info_uses_larger_douban_episode_count_for_selected_season(monkeypatch):
+    service = MediaProviderService()
+    details = _tmdb_details(provider_id=280133, media_type="tv")
+    details.seasons = [MediaSeasonInfo(season_number=1, episode_count=10, air_date="2026-01-01")]
+    details.episodes_count = 10
+    monkeypatch.setattr(
+        service.detail,
+        "get_tmdb_detail_bundle",
+        AsyncMock(return_value=(details, [])),
+    )
+    monkeypatch.setattr(
+        service.mapping,
+        "get_cached_tmdb_mapping",
+        AsyncMock(return_value=(280133, None, "35653123", 1, None)),
+    )
+    set_cached = AsyncMock()
+    monkeypatch.setattr(service.mapping, "set_cached_tmdb_mapping", set_cached)
+    douban_client = SimpleNamespace(
+        get_subject_detail=AsyncMock(return_value=SimpleNamespace(
+            overview="Douban plot",
+            rating=ProviderRating(value=7.1, count=100),
+            vendors=[],
+            episodes_count=23,
+        )),
+    )
+    monkeypatch.setattr(service.clients, "get_douban_client", lambda: douban_client)
+
+    media = await service.info(MediaID.parse("tmdb:tv:280133"), season_number=1)
+
+    assert media is not None
+    assert media.episodes_count == 23
+    assert media.episode_count_override == 23
+    set_cached.assert_awaited_once_with(
+        MediaID.parse("tmdb:tv:280133"),
+        280133,
+        "tt0499549",
+        "35653123",
+        1,
+        23,
+    )
+
+
+@pytest.mark.asyncio
 async def test_attach_source_tmdb_mapping_keeps_episode_count_override_season_scoped(monkeypatch):
     service = MediaProviderService()
     details = _tmdb_details(provider_id=1396, media_type="tv")
@@ -166,7 +210,11 @@ async def test_attach_source_tmdb_mapping_keeps_episode_count_override_season_sc
         MediaSeasonInfo(season_number=2, episode_count=12, air_date="2025-01-01"),
     ]
     douban_client = SimpleNamespace(
-        get_subject_detail=AsyncMock(return_value=SimpleNamespace(title="Breaking Bad Season 2", year=2025)),
+        get_subject_detail=AsyncMock(return_value=SimpleNamespace(
+            title="Breaking Bad Season 2",
+            year=2025,
+            episodes_count=None,
+        )),
     )
     set_cached = AsyncMock()
     monkeypatch.setattr(service.clients, "get_douban_client", lambda: douban_client)
@@ -191,7 +239,11 @@ async def test_attach_source_tmdb_mapping_uses_default_tmdb_season(monkeypatch):
     details = _tmdb_details(provider_id=1396, media_type="tv")
     details.seasons = [MediaSeasonInfo(season_number=1, episode_count=10)]
     douban_client = SimpleNamespace(
-        get_subject_detail=AsyncMock(return_value=SimpleNamespace(title="Breaking Bad", year=None)),
+        get_subject_detail=AsyncMock(return_value=SimpleNamespace(
+            title="Breaking Bad",
+            year=None,
+            episodes_count=None,
+        )),
     )
     set_cached = AsyncMock()
     monkeypatch.setattr(service.clients, "get_douban_client", lambda: douban_client)

--- a/backend/tests/test_media_source_canonical.py
+++ b/backend/tests/test_media_source_canonical.py
@@ -196,7 +196,7 @@ def test_build_tmdb_media_info_uses_manual_episode_count_without_guessing_next_a
     assert media.status_label == "Airing"
 
 
-def test_build_tmdb_media_info_uses_larger_tmdb_episode_count():
+def test_build_tmdb_media_info_preserves_manual_episode_count_override():
     details = _tmdb_details(100088)
     details.seasons = [MediaSeasonInfo(season_number=2, episode_count=120, air_date="2025-01-01")]
     details.episodes_count = 120
@@ -218,14 +218,39 @@ def test_build_tmdb_media_info_uses_larger_tmdb_episode_count():
         rating_source="douban",
         season_number=2,
         vendors=[],
+        douban_episode_count=37,
         episode_count_override=24,
     )
 
-    assert media.episodes_count == 120
-    assert media.episode_count_override == 120
+    assert media.episodes_count == 24
+    assert media.episode_count_override == 24
     selected_season = next(season for season in media.seasons if season.season_number == 2)
     assert selected_season.episode_count == 120
-    assert selected_season.episode_count_override == 120
+    assert selected_season.episode_count_override == 24
+
+
+def test_build_tmdb_media_info_uses_larger_tmdb_count_without_manual_override():
+    details = _tmdb_details(100088)
+    details.seasons = [MediaSeasonInfo(season_number=2, episode_count=120, air_date="2025-01-01")]
+    details.episodes_count = 120
+
+    media = build_tmdb_media_info(
+        mid=MediaID.parse("tmdb:tv:100088"),
+        details=details,
+        imdb_id=None,
+        vote_average=None,
+        rating_count=None,
+        rating_source="douban",
+        season_number=2,
+        vendors=[],
+        douban_episode_count=24,
+    )
+
+    assert media.episodes_count == 120
+    assert media.episode_count_override is None
+    selected_season = next(season for season in media.seasons if season.season_number == 2)
+    assert selected_season.episode_count == 120
+    assert selected_season.episode_count_override is None
 
 
 @pytest.mark.asyncio
@@ -261,11 +286,11 @@ async def test_douban_source_uses_larger_douban_episode_count(monkeypatch):
     media = await service.info_from_source(MediaSourceLookup(source="douban", source_id="douban-tv-count", media_type=MediaType.tv))
 
     assert media.episodes_count == 37
-    assert next(season for season in media.seasons if season.season_number == media.season_number).episode_count == 10
-    assert next(season for season in media.seasons if season.season_number == media.season_number).episode_count_override == 37
+    assert next(season for season in media.seasons if season.season_number == media.season_number).episode_count == 37
+    assert next(season for season in media.seasons if season.season_number == media.season_number).episode_count_override is None
     mapping = MediaExternalMappingRepository().find_by_douban_id("douban-tv-count", "tv")
     assert mapping is not None
-    assert mapping.episode_count_override == 37
+    assert mapping.episode_count_override is None
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_media_source_canonical.py
+++ b/backend/tests/test_media_source_canonical.py
@@ -196,7 +196,7 @@ def test_build_tmdb_media_info_uses_manual_episode_count_without_guessing_next_a
     assert media.status_label == "Airing"
 
 
-def test_build_tmdb_media_info_uses_manual_episode_count_override():
+def test_build_tmdb_media_info_uses_larger_tmdb_episode_count():
     details = _tmdb_details(100088)
     details.seasons = [MediaSeasonInfo(season_number=2, episode_count=120, air_date="2025-01-01")]
     details.episodes_count = 120
@@ -221,11 +221,11 @@ def test_build_tmdb_media_info_uses_manual_episode_count_override():
         episode_count_override=24,
     )
 
-    assert media.episodes_count == 24
-    assert media.episode_count_override == 24
+    assert media.episodes_count == 120
+    assert media.episode_count_override == 120
     selected_season = next(season for season in media.seasons if season.season_number == 2)
     assert selected_season.episode_count == 120
-    assert selected_season.episode_count_override == 24
+    assert selected_season.episode_count_override == 120
 
 
 @pytest.mark.asyncio
@@ -246,7 +246,7 @@ async def test_douban_source_detail_returns_tmdb_canonical_media_id(monkeypatch)
 
 
 @pytest.mark.asyncio
-async def test_douban_source_episode_count_does_not_override_tmdb_episode_count(monkeypatch):
+async def test_douban_source_uses_larger_douban_episode_count(monkeypatch):
     class EpisodeCountDoubanClient(FakeDoubanClient):
         async def get_subject_detail(self, source_id, subject_type):
             detail = await super().get_subject_detail(source_id, subject_type)
@@ -260,8 +260,12 @@ async def test_douban_source_episode_count_does_not_override_tmdb_episode_count(
 
     media = await service.info_from_source(MediaSourceLookup(source="douban", source_id="douban-tv-count", media_type=MediaType.tv))
 
-    assert media.episodes_count == 10
+    assert media.episodes_count == 37
     assert next(season for season in media.seasons if season.season_number == media.season_number).episode_count == 10
+    assert next(season for season in media.seasons if season.season_number == media.season_number).episode_count_override == 37
+    mapping = MediaExternalMappingRepository().find_by_douban_id("douban-tv-count", "tv")
+    assert mapping is not None
+    assert mapping.episode_count_override == 37
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- merge season episode counts from Douban, TMDB, and existing scoped mappings by choosing the largest positive value
- persist Douban episode counts for automatic and manual source mappings
- keep refreshed profile and season scope counts aligned with the resolved maximum

## Tests

- `./scripts/review_with_gates.sh`
- `./aethera.sh test-backend tests/test_media_profile_service_simple_info.py tests/test_media_provider_service_tmdb_source.py`

## Runtime verification

- refreshed `tmdb:tv:280133` season 1 locally
- verified the detail projection, profile, season scope, and mapping report 23 episodes