### PR TITLE
Reject torrent files from mismatched seasons

### DIFF
--- a/backend/app/services/application/workflows/subscription/pilot.py
+++ b/backend/app/services/application/workflows/subscription/pilot.py
@@ -222,6 +222,7 @@ class PilotDownloadApplicationService:
                 standard_results,
                 quality_profile=selection_plan.quality_profile,
                 target_episodes=selection_plan.target_episodes,
+                season_number=selection_plan.season_number,
             )
         return await select_download_resources(
             standard_results,

--- a/backend/app/services/application/workflows/subscription/run.py
+++ b/backend/app/services/application/workflows/subscription/run.py
@@ -253,6 +253,7 @@ class SubscriptionRunApplicationService:
             quality_profile=plan.quality_profile,
             required_scores=plan.required_scores,
             episode_mode=plan.episode_mode,
+            season_number=plan.season_number,
             existing_disc_numbers=plan.existing_disc_numbers,
         )
         return ResourceRunSelection(
@@ -595,6 +596,5 @@ class SubscriptionRunApplicationService:
     async def _acquire_subscription_sweep(self) -> AsyncIterator[bool]:
         async with domain_lock_service.acquire_scheduler_job("subscription_sweep") as acquired:
             yield acquired
-
 
 subscription_run_application_service = SubscriptionRunApplicationService()

--- a/backend/app/services/domain/download/lifecycle.py
+++ b/backend/app/services/domain/download/lifecycle.py
@@ -16,6 +16,7 @@ from app.services.domain.directory import directory_service
 from app.services.config.settings_service import settings_service
 from app.services.domain.resource.parser import resource_parser
 from app.services.domain.resource.torrent_metadata import build_torrent_payload
+from app.services.domain.resource.torrent_season import selected_files_have_season_conflict
 from app.services.integration.torrent import torrent_service
 from app.services.platform.domain_lock_service import domain_lock_service
 from app.utils.library_paths import to_download_relative_path
@@ -314,6 +315,22 @@ class DownloadCreationService:
         logger.debug("Preparing download request: media=%s result_id=%s title=%s", req.media.media_id, req.result_id, search_result.title)
 
         payload = build_torrent_payload(await torrent_service.fetch_blob(search_result), desc=search_result.description)
+        if selected_files_have_season_conflict(
+            payload.metadata,
+            season_number=req.media.season_number,
+            selected_files=req.selected_files,
+        ):
+            logger.warning(
+                "Download request rejected after torrent season verification: media=%s target_season=%s title=%s selected_files=%s",
+                req.media.media_id,
+                req.media.season_number,
+                search_result.title,
+                req.selected_files or [],
+            )
+            raise DownloadException(
+                "backendErrors.downloadTorrentSeasonMismatch",
+                params={"season": str(req.media.season_number)},
+            )
         torrent_service.store_blob(payload.metadata.hash if payload.metadata else None, payload.blob)
         download_target = self.resolve_download_target(req.directory_id)
         async with domain_lock_service.acquire_download_create(

--- a/backend/app/services/domain/resource/pilot_selection.py
+++ b/backend/app/services/domain/resource/pilot_selection.py
@@ -10,6 +10,7 @@ from app.services.domain.resource.filtering import compute_preference_score
 from app.services.domain.resource.quality import RESOURCE_FORM_BLURAY_DISC, RESOURCE_FORM_DVD_DISC
 from app.services.domain.resource.selection import automatic_resource_sort_rank, has_valid_seeders
 from app.services.domain.resource.torrent_metadata import fetch_torrent_payload
+from app.services.domain.resource.torrent_season import select_torrent_episode_files, torrent_episodes_for_season
 
 logger = logging.getLogger("app.services.resource.pilot_selection")
 
@@ -19,6 +20,7 @@ async def select_pilot_resources(
     *,
     quality_profile: QualityProfile | None = None,
     target_episodes: set[int],
+    season_number: int | None = None,
 ) -> list[tuple[TorrentPayload, list[int], Resource]] | None:
     candidate_items: list[tuple[Resource, set[int], int, int, TorrentPayload | None]] = []
     for result in results:
@@ -105,14 +107,14 @@ async def select_pilot_resources(
         finalized_items: list[tuple[TorrentPayload, list[int], Resource, set[int]]] = []
         finalized_coverage: set[int] = set()
         for result, covered, _preference_score, _seeders, payload in fallback_candidates:
-            finalized = await finalize_pilot_resource(result, covered, payload)
+            finalized = await finalize_pilot_resource(result, covered, payload, season_number=season_number)
             if not finalized:
                 continue
             remaining_episodes = target_episodes - finalized_coverage
-            effective_covered = set(finalized[0].metadata.get_episodes()) & remaining_episodes
+            effective_covered = torrent_episodes_for_season(finalized[0].metadata, season_number) & remaining_episodes
             if not effective_covered:
                 continue
-            finalized = await finalize_pilot_resource(result, effective_covered, finalized[0])
+            finalized = await finalize_pilot_resource(result, effective_covered, finalized[0], season_number=season_number)
             if not finalized:
                 continue
             finalized_coverage.update(effective_covered)
@@ -166,16 +168,16 @@ async def select_pilot_resources(
             if not provisional_covered:
                 continue
 
-            finalized = await finalize_pilot_resource(result, provisional_covered, payload)
+            finalized = await finalize_pilot_resource(result, provisional_covered, payload, season_number=season_number)
             if not finalized:
                 combo_valid = False
                 break
 
             finalized_payload = finalized[0]
-            payload_episodes = set(finalized_payload.metadata.get_episodes())
+            payload_episodes = torrent_episodes_for_season(finalized_payload.metadata, season_number)
             effective_covered = (payload_episodes & remaining_episodes) or provisional_covered
             if effective_covered != provisional_covered:
-                finalized = await finalize_pilot_resource(result, effective_covered, finalized_payload)
+                finalized = await finalize_pilot_resource(result, effective_covered, finalized_payload, season_number=season_number)
                 if not finalized:
                     combo_valid = False
                     break
@@ -209,6 +211,8 @@ async def finalize_pilot_resource(
     result: Resource | None,
     covered: set[int],
     payload: TorrentPayload | None = None,
+    *,
+    season_number: int | None = None,
 ) -> tuple[TorrentPayload, list[int], Resource] | None:
     if not result or not covered:
         return None
@@ -218,7 +222,7 @@ async def finalize_pilot_resource(
         logger.warning("Failed to finalize pilot torrent payload: title=%s error=%s", result.resources.title, exc)
         return None
 
-    payload_episodes = set(payload.metadata.get_episodes())
+    payload_episodes = torrent_episodes_for_season(payload.metadata, season_number)
     if payload.metadata.attrs and payload.metadata.attrs.resource_form in {RESOURCE_FORM_BLURAY_DISC, RESOURCE_FORM_DVD_DISC}:
         logger.debug("Pilot payload skipped: title=%s reason=disc_package", result.resources.title)
         return None
@@ -240,11 +244,11 @@ async def finalize_pilot_resource(
             sorted(covered),
         )
 
-    selected_files = [
-        index
-        for index, file in enumerate(payload.metadata.files)
-        if file.get_episodes() and file.get_episodes() & covered
-    ]
+    selected_files = select_torrent_episode_files(
+        payload.metadata,
+        season_number=season_number,
+        episodes=covered,
+    )
     if selected_files:
         selected_covered = set().union(*(payload.metadata.files[index].get_episodes() or set() for index in selected_files))
         if not covered.issubset(selected_covered):

--- a/backend/app/services/domain/resource/selection.py
+++ b/backend/app/services/domain/resource/selection.py
@@ -24,6 +24,11 @@ from app.services.domain.resource.filtering import (
 from app.services.domain.resource.parser import resource_parser
 from app.services.domain.resource.quality import quality_sort_key
 from app.services.domain.resource.torrent_metadata import fetch_torrent_payload
+from app.services.domain.resource.torrent_season import (
+    select_torrent_episode_files,
+    selected_files_have_season_conflict,
+    torrent_episodes_for_season,
+)
 
 logger = logging.getLogger("app.services.resource.selection")
 
@@ -225,6 +230,7 @@ async def select_resources(
     quality_profile: QualityProfile | None = None,
     required_scores: Mapping[int, int] | None = None,
     episode_mode: bool = True,
+    season_number: int | None = None,
     existing_disc_numbers: set[int] | None = None,
 ) -> list[tuple[TorrentPayload, list[int], Resource]]:
     if episode_mode and allows_disc_package_subscription(filters):
@@ -237,12 +243,14 @@ async def select_resources(
                 quality_profile=quality_profile,
                 required_scores=required_scores,
                 episode_mode=episode_mode,
+                season_number=season_number,
             ))
         selected.extend(await _select_disc_package_resources(
             results,
             filters=filters,
             quality_profile=quality_profile,
             existing_disc_numbers=existing_disc_numbers or set(),
+            season_number=season_number,
         ))
         return selected
     return await _select_video_file_resources(
@@ -252,6 +260,7 @@ async def select_resources(
         quality_profile=quality_profile,
         required_scores=required_scores,
         episode_mode=episode_mode,
+        season_number=season_number,
     )
 
 
@@ -263,6 +272,7 @@ async def _select_video_file_resources(
     quality_profile: QualityProfile | None = None,
     required_scores: Mapping[int, int] | None = None,
     episode_mode: bool = True,
+    season_number: int | None = None,
 ) -> list[tuple[TorrentPayload, list[int], Resource]]:
     needed_episodes = set(episodes) if episodes else set()
     candidates = [result for result in results if has_valid_seeders(result) and match_filters(result, filters, quality_profile)]
@@ -301,7 +311,7 @@ async def _select_video_file_resources(
             if not match_filters(best_resource, filters, quality_profile):
                 candidates.remove(original_best_resource)
                 continue
-            real_episodes = payload.metadata.get_episodes()
+            real_episodes = torrent_episodes_for_season(payload.metadata, season_number)
             best_upgrade_score = compute_quality_upgrade_score(best_resource, quality_profile)
             real_covered = {
                 ep
@@ -338,7 +348,7 @@ async def _select_video_file_resources(
         if not match_filters(best_resource, filters, quality_profile):
             candidates.remove(original_best_resource)
             continue
-        real_episodes = payload.metadata.get_episodes() or (set(needed_episodes) if not episode_mode else set())
+        real_episodes = torrent_episodes_for_season(payload.metadata, season_number) or (set(needed_episodes) if not episode_mode else set())
         best_upgrade_score = compute_quality_upgrade_score(best_resource, quality_profile)
         real_covered = {
             ep
@@ -367,11 +377,11 @@ async def _select_video_file_resources(
             elif not episode_mode:
                 selected_files = []
             else:
-                selected_files = []
-                for index, file in enumerate(payload.metadata.files):
-                    file_episodes = file.get_episodes()
-                    if file_episodes and file_episodes & covered:
-                        selected_files.append(index)
+                selected_files = select_torrent_episode_files(
+                    payload.metadata,
+                    season_number=season_number,
+                    episodes=covered,
+                )
             if selected_files or not episode_mode:
                 final_results.append((payload, selected_files, result))
             else:
@@ -388,6 +398,7 @@ async def _select_disc_package_resources(
     filters: ResourceFilters | None,
     quality_profile: QualityProfile | None = None,
     existing_disc_numbers: set[int] | None = None,
+    season_number: int | None = None,
 ) -> list[tuple[TorrentPayload, list[int], Resource]]:
     candidates = sorted(
         [result for result in results if has_valid_seeders(result)],
@@ -404,6 +415,17 @@ async def _select_disc_package_resources(
             logger.warning("Failed to fetch resource torrent payload: title=%s error=%s", result.resources.title, exc)
             continue
         enriched = _resource_with_metadata_attrs(result, payload)
+        if selected_files_have_season_conflict(
+            payload.metadata,
+            season_number=season_number,
+            selected_files=None,
+        ):
+            logger.debug(
+                "Discarded disc resource after payload season verification: title=%s target_season=%s",
+                result.resources.title,
+                season_number,
+            )
+            continue
         attrs = enriched.attrs
         if not attrs.resource_form or not match_filters(enriched, filters, quality_profile):
             continue

--- a/backend/app/services/domain/resource/torrent_metadata.py
+++ b/backend/app/services/domain/resource/torrent_metadata.py
@@ -82,7 +82,7 @@ def enrich_torrent_metadata(metadata: TorrentMetadata, desc: str = "") -> Torren
     root_attrs = resource_parser.parse(metadata.name, desc=desc)
     form, source, layout = _detect_disc_structure(metadata.name, metadata.files)
     enriched_files = [
-        file_item.model_copy(update={"attrs": _merge_file_attrs(file_item, form, source, layout)})
+        file_item.model_copy(update={"attrs": _merge_file_attrs(file_item, metadata.name, form, source, layout)})
         for file_item in metadata.files
     ]
     package_attrs = _merge_package_attrs(root_attrs, enriched_files, form, source, layout)
@@ -128,20 +128,40 @@ def _detect_disc_structure(name: str, files: list[TorrentFileItem]) -> tuple[str
     return None, None, PackageLayoutValue.ISO if iso else None
 
 
-def _merge_file_attrs(file_item: TorrentFileItem, form: str | None, source: str | None, layout: str | None) -> ResourceAttributes:
+def _merge_file_attrs(
+    file_item: TorrentFileItem,
+    root_name: str,
+    form: str | None,
+    source: str | None,
+    layout: str | None,
+) -> ResourceAttributes:
     attrs = file_item.attrs or resource_parser.parse(file_item.filename)
-    filename_attrs = resource_parser.parse(PurePosixPath(file_item.filename).name)
     sources = list(attrs.sources or [])
     if source and source not in sources:
         sources.append(source)
     updates = {
         "sources": sources,
-        "seasons": list(filename_attrs.seasons or []),
+        "seasons": _file_season_evidence(file_item.filename, root_name),
         "package_layout": layout or attrs.package_layout,
     }
     if form:
         updates.update({"resource_form": form, "resource_form_evidence": ResourceFormEvidence.TORRENT_STRUCTURE})
     return attrs.model_copy(update=updates)
+
+
+def _file_season_evidence(filename: str, root_name: str) -> list[int]:
+    path = PurePosixPath(filename)
+    filename_attrs = resource_parser.parse(path.name)
+    if filename_attrs.seasons:
+        return list(filename_attrs.seasons)
+
+    directory_parts = list(path.parts[:-1])
+    if directory_parts and directory_parts[0].strip() == root_name.strip():
+        directory_parts = directory_parts[1:]
+    if not directory_parts:
+        return []
+    directory_attrs = resource_parser.parse("/".join(directory_parts))
+    return list(directory_attrs.seasons or [])
 
 
 def _merge_package_attrs(

--- a/backend/app/services/domain/resource/torrent_metadata.py
+++ b/backend/app/services/domain/resource/torrent_metadata.py
@@ -130,12 +130,15 @@ def _detect_disc_structure(name: str, files: list[TorrentFileItem]) -> tuple[str
 
 def _merge_file_attrs(file_item: TorrentFileItem, form: str | None, source: str | None, layout: str | None) -> ResourceAttributes:
     attrs = file_item.attrs or resource_parser.parse(file_item.filename)
-    if not form and not layout:
-        return attrs
+    filename_attrs = resource_parser.parse(PurePosixPath(file_item.filename).name)
     sources = list(attrs.sources or [])
     if source and source not in sources:
         sources.append(source)
-    updates = {"sources": sources, "package_layout": layout or attrs.package_layout}
+    updates = {
+        "sources": sources,
+        "seasons": list(filename_attrs.seasons or []),
+        "package_layout": layout or attrs.package_layout,
+    }
     if form:
         updates.update({"resource_form": form, "resource_form_evidence": ResourceFormEvidence.TORRENT_STRUCTURE})
     return attrs.model_copy(update=updates)

--- a/backend/app/services/domain/resource/torrent_season.py
+++ b/backend/app/services/domain/resource/torrent_season.py
@@ -13,7 +13,7 @@ def torrent_file_matches_season(
     if season_number is None:
         return True
     seasons = _explicit_file_seasons(metadata, file_item)
-    return not seasons or season_number in seasons
+    return not seasons or seasons == {season_number}
 
 
 def torrent_episodes_for_season(
@@ -55,7 +55,7 @@ def selected_files_have_season_conflict(
     indices = list(selected_files or range(len(metadata.files)))
     if not indices:
         seasons = _explicit_metadata_seasons(metadata)
-        return bool(seasons and season_number not in seasons)
+        return bool(seasons and seasons != {season_number})
     for index in indices:
         if 0 <= index < len(metadata.files) and not torrent_file_matches_season(
             metadata,

--- a/backend/app/services/domain/resource/torrent_season.py
+++ b/backend/app/services/domain/resource/torrent_season.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from app.schemas.domain.torrent import TorrentFileItem, TorrentMetadata
+
+
+def torrent_file_matches_season(
+    metadata: TorrentMetadata,
+    file_item: TorrentFileItem,
+    season_number: int | None,
+) -> bool:
+    if season_number is None:
+        return True
+    seasons = _explicit_file_seasons(metadata, file_item)
+    return not seasons or season_number in seasons
+
+
+def torrent_episodes_for_season(
+    metadata: TorrentMetadata,
+    season_number: int | None,
+) -> set[int]:
+    if season_number is None:
+        return set(metadata.get_episodes())
+    episodes: set[int] = set()
+    for file_item in metadata.files:
+        if torrent_file_matches_season(metadata, file_item, season_number):
+            episodes.update(file_item.get_episodes())
+    return episodes
+
+
+def select_torrent_episode_files(
+    metadata: TorrentMetadata,
+    *,
+    season_number: int | None,
+    episodes: set[int],
+) -> list[int]:
+    return [
+        index
+        for index, file_item in enumerate(metadata.files)
+        if torrent_file_matches_season(metadata, file_item, season_number)
+        and file_item.get_episodes()
+        and file_item.get_episodes() & episodes
+    ]
+
+
+def selected_files_have_season_conflict(
+    metadata: TorrentMetadata,
+    *,
+    season_number: int | None,
+    selected_files: Iterable[int] | None,
+) -> bool:
+    if season_number is None:
+        return False
+    indices = list(selected_files or range(len(metadata.files)))
+    if not indices:
+        seasons = _explicit_metadata_seasons(metadata)
+        return bool(seasons and season_number not in seasons)
+    for index in indices:
+        if 0 <= index < len(metadata.files) and not torrent_file_matches_season(
+            metadata,
+            metadata.files[index],
+            season_number,
+        ):
+            return True
+    return False
+
+
+def _explicit_file_seasons(
+    metadata: TorrentMetadata,
+    file_item: TorrentFileItem,
+) -> set[int]:
+    if file_item.attrs and file_item.attrs.seasons:
+        return {season for season in file_item.attrs.seasons if season > 0}
+    if metadata.attrs and metadata.attrs.seasons:
+        return _explicit_metadata_seasons(metadata)
+    return set()
+
+
+def _explicit_metadata_seasons(metadata: TorrentMetadata) -> set[int]:
+    if not metadata.attrs or not metadata.attrs.seasons:
+        return set()
+    return {season for season in metadata.attrs.seasons if season > 0}

--- a/backend/app/services/i18n/locales/en-US.json
+++ b/backend/app/services/i18n/locales/en-US.json
@@ -34,6 +34,7 @@
   "backendErrors.taskStorageChangeBlocked": "Storage change blocked: {reason}",
   "backendErrors.libraryFileDirectoryChangeBlocked": "Local resource directory change blocked: {reason}",
   "backendErrors.directoryNotFound": "Directory not found",
+  "backendErrors.downloadTorrentSeasonMismatch": "The torrent file season does not match target season {season}; download was blocked",
   "backendErrors.taskNotFound": "Task not found",
   "backendErrors.transferFailed": "Transfer failed: {reason}",
   "runtimeReasons.danmuDurationMismatch": "Video duration mismatch",

--- a/backend/app/services/i18n/locales/zh-CN.json
+++ b/backend/app/services/i18n/locales/zh-CN.json
@@ -34,6 +34,7 @@
   "backendErrors.taskStorageChangeBlocked": "更换存储被阻止：{reason}",
   "backendErrors.libraryFileDirectoryChangeBlocked": "更换本地资源目录被阻止：{reason}",
   "backendErrors.directoryNotFound": "目录不存在",
+  "backendErrors.downloadTorrentSeasonMismatch": "种子内部文件的季号与目标第 {season} 季不一致，已阻止下载",
   "backendErrors.taskNotFound": "任务不存在",
   "backendErrors.transferFailed": "转移失败：{reason}",
   "runtimeReasons.danmuDurationMismatch": "视频时长不匹配",

--- a/backend/tests/test_download_default_tag.py
+++ b/backend/tests/test_download_default_tag.py
@@ -1,7 +1,7 @@
 from contextlib import asynccontextmanager
 from datetime import datetime
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
@@ -90,6 +90,89 @@ def test_resolve_download_target_wraps_configuration_error_as_i18n_reason(monkey
         "reason_key": "backendErrors.config.directoryNotFound",
         "reason_params": {"id": "dir-1"},
     }
+
+
+@pytest.mark.asyncio
+async def test_create_download_rejects_selected_file_from_another_season(monkeypatch):
+    media = MediaExecutionSnapshot(
+        media_id=MediaID.parse("tmdb:tv:1"),
+        title="Show",
+        year=2026,
+        media_type=MediaType.tv,
+        season_number=1,
+        episodes_count=30,
+    )
+    search_result = ResourceSearchResult(
+        id="result-1",
+        title="Show.S01.Complete.2160p.WEB-DL",
+        site="site-a",
+        category="tv",
+        size="1 GiB",
+        seeders=1,
+        leechers=0,
+        publish_date=datetime.now(),
+        download_url="https://example.com/file.torrent",
+        result_id="result-1",
+    )
+    payload = TorrentPayload(
+        metadata=TorrentMetadata(
+            hash="wrong-season",
+            name="Show.S02.2160p.WEB-DL",
+            size=1,
+            files=[
+                TorrentFileItem(
+                    index=0,
+                    filename="Show.S02E30.mkv",
+                    size=1,
+                    attrs=ResourceAttributes(
+                        title="Show.S02E30",
+                        seasons=[2],
+                        episodes=[30],
+                        sources=["WEB-DL"],
+                        resource_form="Video File",
+                    ),
+                )
+            ],
+            attrs=ResourceAttributes(
+                title="Show.S02.2160p.WEB-DL",
+                seasons=[2],
+                episodes=[30],
+                sources=["WEB-DL"],
+                resource_form="Video File",
+            ),
+            coverage_kind="exact_episodes",
+        ),
+        blob=b"torrent-data",
+    )
+    store_blob = Mock()
+    service = DownloadCreationService(None, None, None, None)
+    monkeypatch.setattr(
+        "app.services.domain.download.lifecycle.torrent_service.fetch_blob",
+        AsyncMock(return_value=b"torrent-data"),
+    )
+    monkeypatch.setattr(
+        "app.services.domain.download.lifecycle.build_torrent_payload",
+        lambda _blob, desc=None: payload,
+    )
+    monkeypatch.setattr(
+        "app.services.domain.download.lifecycle.torrent_service.store_blob",
+        store_blob,
+    )
+
+    with pytest.raises(DownloadException) as exc_info:
+        await service.create_download(
+            DownloadTaskCreateInput(
+                media=media,
+                directory_id="dir-1",
+                result_id="result-1",
+                selected_files=[0],
+            ),
+            search_result,
+        )
+
+    assert exc_info.value.message_key == "backendErrors.downloadTorrentSeasonMismatch"
+    assert exc_info.value.params == {"season": "1"}
+    store_blob.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_subscription_execution_drift.py
+++ b/backend/tests/test_subscription_execution_drift.py
@@ -949,6 +949,41 @@ async def test_select_resources_continues_after_known_candidate_payload_misses_t
 
 
 @pytest.mark.asyncio
+async def test_select_resources_rejects_payload_files_from_another_season(monkeypatch):
+    misleading = _video_resource("Show.S01.Complete.2160p.WEB-DL", [30], seeders=50)
+    correct = _video_resource("Show.S01E30.1080p.WEB-DL", [30], seeders=20)
+    wrong_metadata = _video_metadata(misleading.resources.title, [30])
+    wrong_metadata.name = "Show.S02.2160p.WEB-DL"
+    wrong_metadata.attrs = wrong_metadata.attrs.model_copy(update={"seasons": [2]})
+    wrong_metadata.files[0].filename = "Show.S02E30.mkv"
+    wrong_metadata.files[0].attrs = wrong_metadata.files[0].attrs.model_copy(update={"seasons": [2]})
+    payloads = {
+        misleading.resources.title: TorrentPayload(metadata=wrong_metadata, blob=b"wrong-season"),
+        correct.resources.title: TorrentPayload(metadata=_video_metadata(correct.resources.title, [30]), blob=b"correct-season"),
+    }
+
+    async def fake_fetch_payload(result):
+        return payloads[result.title]
+
+    monkeypatch.setattr(
+        "app.services.domain.resource.selection.fetch_torrent_payload",
+        fake_fetch_payload,
+    )
+
+    selected = await select_resources(
+        [misleading, correct],
+        episodes={30},
+        filters=SubscriptionFilters(resource_kind=["video_file"]),
+        episode_mode=True,
+        season_number=1,
+    )
+
+    assert len(selected) == 1
+    assert selected[0][2].resources.title == correct.resources.title
+    assert selected[0][1] == [0]
+
+
+@pytest.mark.asyncio
 async def test_original_disc_category_only_selects_disc_package(monkeypatch):
     resources = [_disc_resource("Show.S01.Disc.1.of.1", seeders=20), _video_resource("Show.S01E01.1080p.WEB-DL", [1], seeders=50)]
     payloads = {

--- a/backend/tests/test_subscription_execution_pilot.py
+++ b/backend/tests/test_subscription_execution_pilot.py
@@ -183,7 +183,7 @@ async def test_pilot_can_combine_multiple_resources_to_cover_first_three_episode
         _build_resource("single-3", [3], seeders=8),
     ]
 
-    async def fake_finalize(result, covered, payload=None):
+    async def fake_finalize(result, covered, payload=None, *, season_number=None):
         return _build_pilot_payload(covered), [], result
 
     monkeypatch.setattr("app.services.domain.resource.pilot_selection.finalize_pilot_resource", fake_finalize)
@@ -210,7 +210,7 @@ async def test_pilot_prefers_higher_quality_combo_over_lower_quality_full_pack(m
         _build_resource("single-high-3", [3], seeders=8),
     ]
 
-    async def fake_finalize(result, covered, payload=None):
+    async def fake_finalize(result, covered, payload=None, *, season_number=None):
         return _build_pilot_payload(covered), [], result
 
     def fake_score(result, filters):
@@ -243,7 +243,7 @@ async def test_pilot_does_not_fetch_payload_during_selection_for_attrless_candid
         _build_resource("full-unknown", None, seeders=20),
     ]
 
-    async def fake_finalize(result, covered, payload=None):
+    async def fake_finalize(result, covered, payload=None, *, season_number=None):
         return _build_pilot_payload(covered), [], result
 
     async def fail_fetch_payload(_url):
@@ -272,7 +272,7 @@ async def test_pilot_prefers_better_builtin_quality_before_seeders(monkeypatch):
         _build_resource("dv-pack", [1, 2, 3], seeders=5, hdr_type="Dolby Vision"),
     ]
 
-    async def fake_finalize(result, covered, payload=None):
+    async def fake_finalize(result, covered, payload=None, *, season_number=None):
         return _build_pilot_payload(covered), [], result
 
     monkeypatch.setattr("app.services.domain.resource.pilot_selection.finalize_pilot_resource", fake_finalize)
@@ -355,6 +355,47 @@ async def test_pilot_finalization_selects_only_missing_episode_files_from_pack()
 
     assert finalized is not None
     assert finalized[1] == [0]
+
+
+@pytest.mark.asyncio
+async def test_pilot_finalization_rejects_payload_files_from_another_season():
+    resource = _build_resource("Show.S01.Complete.2160p.WEB-DL", [30])
+    metadata = TorrentMetadata(
+        hash="wrong-season",
+        name="Show.S02.2160p.WEB-DL",
+        size=1,
+        files=[
+            TorrentFileItem(
+                index=0,
+                filename="Show.S02E30.mkv",
+                size=1,
+                attrs=ResourceAttributes(
+                    title="Show.S02E30",
+                    seasons=[2],
+                    episodes=[30],
+                    sources=["WEB-DL"],
+                    resource_form="Video File",
+                ),
+            )
+        ],
+        attrs=ResourceAttributes(
+            title="Show.S02.2160p.WEB-DL",
+            seasons=[2],
+            episodes=[30],
+            sources=["WEB-DL"],
+            resource_form="Video File",
+        ),
+        coverage_kind="exact_episodes",
+    )
+
+    finalized = await finalize_pilot_resource(
+        resource,
+        {30},
+        TorrentPayload(metadata=metadata, blob=b"wrong-season"),
+        season_number=1,
+    )
+
+    assert finalized is None
 
 
 @pytest.mark.asyncio
@@ -500,7 +541,7 @@ async def test_subscription_prefers_better_builtin_quality_before_seeders():
 
     async def fake_fetch_payload(_url):
         file_item = SimpleNamespace(get_episodes=lambda: {1})
-        metadata = SimpleNamespace(files=[file_item], get_episodes=lambda: {1}, name="payload", size=1)
+        metadata = SimpleNamespace(attrs=None, files=[file_item], get_episodes=lambda: {1}, name="payload", size=1)
         return SimpleNamespace(metadata=metadata)
 
     from app.services.domain.resource import selection as resource_selection_module
@@ -532,7 +573,7 @@ async def test_subscription_selection_filters_zero_seeders_even_when_quality_is_
 
     async def fake_fetch_payload(result):
         file_item = SimpleNamespace(get_episodes=lambda: {1})
-        metadata = SimpleNamespace(files=[file_item], get_episodes=lambda: {1}, name=result.title, size=1)
+        metadata = SimpleNamespace(attrs=None, files=[file_item], get_episodes=lambda: {1}, name=result.title, size=1)
         return SimpleNamespace(metadata=metadata)
 
     monkeypatch.setattr("app.services.domain.resource.selection.fetch_torrent_payload", fake_fetch_payload)
@@ -563,7 +604,7 @@ async def test_subscription_selection_prefers_seeders_over_stereo_channel_only_a
 
     async def fake_fetch_payload(result):
         file_item = SimpleNamespace(get_episodes=lambda: {1})
-        metadata = SimpleNamespace(files=[file_item], get_episodes=lambda: {1}, name=result.title, size=1)
+        metadata = SimpleNamespace(attrs=None, files=[file_item], get_episodes=lambda: {1}, name=result.title, size=1)
         return SimpleNamespace(metadata=metadata)
 
     monkeypatch.setattr("app.services.domain.resource.selection.fetch_torrent_payload", fake_fetch_payload)
@@ -592,7 +633,7 @@ async def test_subscription_selection_does_not_let_tiny_hdr_beat_healthy_2160p(m
 
     async def fake_fetch_payload(result):
         file_item = SimpleNamespace(get_episodes=lambda: {1})
-        metadata = SimpleNamespace(files=[file_item], get_episodes=lambda: {1}, name=result.title, size=1)
+        metadata = SimpleNamespace(attrs=None, files=[file_item], get_episodes=lambda: {1}, name=result.title, size=1)
         return SimpleNamespace(metadata=metadata)
 
     monkeypatch.setattr("app.services.domain.resource.selection.fetch_torrent_payload", fake_fetch_payload)
@@ -616,7 +657,7 @@ async def test_pilot_selection_filters_zero_seeders_even_when_quality_is_better(
         _build_resource("hdr-seeded", [1, 2, 3], seeders=3, hdr_type="HDR10"),
     ]
 
-    async def fake_finalize(result, covered, payload=None):
+    async def fake_finalize(result, covered, payload=None, *, season_number=None):
         return _build_pilot_payload(covered), [], result
 
     monkeypatch.setattr("app.services.domain.resource.pilot_selection.finalize_pilot_resource", fake_finalize)

--- a/backend/tests/test_torrent_metadata_drift.py
+++ b/backend/tests/test_torrent_metadata_drift.py
@@ -262,3 +262,38 @@ def test_multi_season_torrent_can_select_file_with_one_explicit_target_season():
     assert select_torrent_episode_files(metadata, season_number=1, episodes={1}) == [0]
     assert selected_files_have_season_conflict(metadata, season_number=1, selected_files=[0]) is False
     assert selected_files_have_season_conflict(metadata, season_number=1, selected_files=None) is True
+
+
+def test_nested_single_season_directory_remains_file_season_evidence():
+    payload = bencodepy.encode(
+        OrderedDict(
+            [
+                (
+                    b"info",
+                    OrderedDict(
+                        [
+                            (b"name", b"Show.Name.Complete"),
+                            (
+                                b"files",
+                                [
+                                    OrderedDict(
+                                        [
+                                            (b"length", 123),
+                                            (b"path", [b"Season 2", b"Show.Name.E01.mkv"]),
+                                        ]
+                                    )
+                                ],
+                            ),
+                        ]
+                    ),
+                )
+            ]
+        )
+    )
+
+    metadata = parse_torrent_metadata(payload)
+
+    assert metadata.attrs.seasons == [2]
+    assert metadata.files[0].attrs.seasons == [2]
+    assert select_torrent_episode_files(metadata, season_number=1, episodes={1}) == []
+    assert selected_files_have_season_conflict(metadata, season_number=1, selected_files=[0]) is True

--- a/backend/tests/test_torrent_metadata_drift.py
+++ b/backend/tests/test_torrent_metadata_drift.py
@@ -6,6 +6,10 @@ import bencodepy
 import pytest
 
 from app.services.domain.resource.torrent_metadata import parse_torrent_metadata
+from app.services.domain.resource.torrent_season import (
+    select_torrent_episode_files,
+    selected_files_have_season_conflict,
+)
 
 
 pytestmark = [pytest.mark.drift]
@@ -183,3 +187,78 @@ def test_parse_metadata_keeps_episode_from_description_when_files_have_no_episod
     assert metadata.attrs.desc == "爱情没有神话 第11集 | 类型：剧情 爱情"
     assert metadata.attrs.episodes == [11]
     assert metadata.get_episodes() == {11}
+
+
+def test_multi_season_metadata_cannot_assign_seasonless_episode_file_to_one_season():
+    payload = bencodepy.encode(
+        OrderedDict(
+            [
+                (
+                    b"info",
+                    OrderedDict(
+                        [
+                            (b"name", b"Show.Name.S01-S03"),
+                            (
+                                b"files",
+                                [
+                                    OrderedDict(
+                                        [
+                                            (b"length", 123),
+                                            (b"path", [b"Show.Name.S01-S03", b"Show.Name.E01.mkv"]),
+                                        ]
+                                    )
+                                ],
+                            ),
+                        ]
+                    ),
+                )
+            ]
+        )
+    )
+
+    metadata = parse_torrent_metadata(payload)
+
+    assert metadata.attrs.seasons == [1, 2, 3]
+    assert metadata.files[0].attrs.seasons == []
+    assert select_torrent_episode_files(metadata, season_number=1, episodes={1}) == []
+    assert selected_files_have_season_conflict(metadata, season_number=1, selected_files=[0]) is True
+
+
+def test_multi_season_torrent_can_select_file_with_one_explicit_target_season():
+    payload = bencodepy.encode(
+        OrderedDict(
+            [
+                (
+                    b"info",
+                    OrderedDict(
+                        [
+                            (b"name", b"Show.Name.S01-S02"),
+                            (
+                                b"files",
+                                [
+                                    OrderedDict(
+                                        [
+                                            (b"length", 123),
+                                            (b"path", [b"Show.Name.S01-S02", b"Show.Name.S01E01.mkv"]),
+                                        ]
+                                    ),
+                                    OrderedDict(
+                                        [
+                                            (b"length", 456),
+                                            (b"path", [b"Show.Name.S01-S02", b"Show.Name.S02E01.mkv"]),
+                                        ]
+                                    ),
+                                ],
+                            ),
+                        ]
+                    ),
+                )
+            ]
+        )
+    )
+
+    metadata = parse_torrent_metadata(payload)
+
+    assert select_torrent_episode_files(metadata, season_number=1, episodes={1}) == [0]
+    assert selected_files_have_season_conflict(metadata, season_number=1, selected_files=[0]) is False
+    assert selected_files_have_season_conflict(metadata, season_number=1, selected_files=None) is True

--- a/frontend/src/i18n/locales/en-US.js
+++ b/frontend/src/i18n/locales/en-US.js
@@ -244,6 +244,7 @@ export default {
     http: 'Request failed',
     directoryValidationFailed: 'Directory configuration is invalid: {errors}',
     downloadTorrentPathConflict: 'Torrent already exists and its save path does not match this directory: {expected} -> {actual}',
+    downloadTorrentSeasonMismatch: 'The torrent file season does not match target season {season}; download was blocked',
     mediaServerLinkNotFound: 'Could not find this resource in the bound media library',
     mediaServerLinkUnavailable: 'This resource is not bound to an openable media library',
     mediaServerAuthenticationFailed: 'Media server authentication failed. Check the media server API key',

--- a/frontend/src/i18n/locales/zh-CN.js
+++ b/frontend/src/i18n/locales/zh-CN.js
@@ -244,6 +244,7 @@ export default {
     http: '请求失败',
     directoryValidationFailed: '目录配置无效：{errors}',
     downloadTorrentPathConflict: '种子已存在，且保存路径与当前目录配置不一致：{expected} -> {actual}',
+    downloadTorrentSeasonMismatch: '种子内部文件的季号与目标第 {season} 季不一致，已阻止下载',
     mediaServerLinkNotFound: '未能在绑定的媒体库中找到该资源',
     mediaServerLinkUnavailable: '该资源未绑定可打开的媒体库',
     mediaServerAuthenticationFailed: '媒体服务器认证失败，请检查媒体服务器 API Key',


### PR DESCRIPTION
## Summary

- validate torrent file seasons against the requested TV season after metadata is fetched
- reject mismatched files in subscription and pilot selection while preserving seasonless filename inference
- enforce the same validation before creating a downloader task and expose a localized error

## Tests

- `./aethera.sh test-backend tests/test_subscription_execution_drift.py tests/test_subscription_execution_pilot.py tests/test_download_default_tag.py` (85 passed)
- `./scripts/review_with_gates.sh` (backend quality checks, 247 backend tests, frontend quality/lint/build)

## Risk

Low. The rejection only applies when torrent metadata provides an explicit season that conflicts with the requested season; files without season evidence keep the existing behavior.