### PR TITLE
Avoid repeated indexer health notifications

### DIFF
--- a/backend/app/db/repositories/event_repository.py
+++ b/backend/app/db/repositories/event_repository.py
@@ -45,6 +45,15 @@ class EventRepository:
         )
 
     @staticmethod
+    def refresh_snapshot(row: EventORM, event: Event) -> None:
+        row.ts = event.ts.isoformat()
+        row.message_key = event.message_key
+        row.message_params_json = event.message_params
+        row.search_text = build_event_search_text(event)
+        row.entities_json = [item.model_dump(mode="json") for item in event.entities]
+        row.meta_json = EventRepository._meta_db_value(event.meta)
+
+    @staticmethod
     def _normalize_meta_text(raw) -> str:
         if raw is None or raw == "":
             return ""

--- a/backend/app/db/repositories/indexer_site_health_repository.py
+++ b/backend/app/db/repositories/indexer_site_health_repository.py
@@ -182,6 +182,41 @@ class IndexerSiteHealthRepository:
             session.commit()
             return True
 
+    def refresh_active_unhealthy_event_if_current(
+        self,
+        status: IndexerSiteHealthStatus,
+        event: Event,
+    ) -> bool:
+        with SessionLocal() as session:
+            session.execute(text("BEGIN IMMEDIATE"))
+            row = session.get(
+                IndexerSiteHealthORM,
+                {"indexer_id": status.indexer_id, "site_id": status.site_id},
+            )
+            if not self._matches_outcome(row, status) or row.status != "unhealthy" or not row.notify_pending:
+                session.rollback()
+                return False
+            acknowledgement_exists = (
+                select(EventAcknowledgementORM.event_id)
+                .where(EventAcknowledgementORM.event_id == EventORM.id)
+                .exists()
+            )
+            active_event = session.execute(
+                select(EventORM)
+                .where(EventORM.correlation_id == (event.correlation_id or ""))
+                .where(EventORM.type == EventTypes.INDEXER_SITE_UNHEALTHY.value)
+                .where(EventORM.level == EventLevel.warning.value)
+                .where(not_(acknowledgement_exists))
+                .order_by(EventORM.ts.desc(), EventORM.id.desc())
+                .limit(1)
+            ).scalar_one_or_none()
+            if active_event is None:
+                session.rollback()
+                return False
+            EventRepository.refresh_snapshot(active_event, event)
+            session.commit()
+            return True
+
     def acknowledge_recovered_unhealthy_events(
         self,
         status: IndexerSiteHealthStatus,

--- a/backend/app/services/config/indexer_client_settings.py
+++ b/backend/app/services/config/indexer_client_settings.py
@@ -100,7 +100,7 @@ class IndexerSiteHealthState:
                 status.site_id,
                 exc,
             )
-            return True
+            return False
 
     def _acknowledge_unhealthy_event(self, status: IndexerSiteHealthStatus) -> bool:
         try:

--- a/backend/app/services/config/indexer_client_settings.py
+++ b/backend/app/services/config/indexer_client_settings.py
@@ -87,6 +87,21 @@ class IndexerSiteHealthState:
             )
             return False
 
+    def _refresh_active_unhealthy_event(self, status: IndexerSiteHealthStatus) -> bool:
+        try:
+            return self._repo.refresh_active_unhealthy_event_if_current(
+                status,
+                self._build_unhealthy_event(status),
+            )
+        except Exception as exc:
+            logger.error(
+                "Failed to refresh active indexer site unhealthy event for %s/%s: %s",
+                status.indexer_id,
+                status.site_id,
+                exc,
+            )
+            return True
+
     def _acknowledge_unhealthy_event(self, status: IndexerSiteHealthStatus) -> bool:
         try:
             applied, acknowledged_count = self._repo.acknowledge_recovered_unhealthy_events(
@@ -109,28 +124,6 @@ class IndexerSiteHealthState:
                 exc,
             )
             return False
-
-    def _reopen_unhealthy_event(self, status: IndexerSiteHealthStatus) -> None:
-        try:
-            applied, reopened_count = self._repo.reopen_unhealthy_events(
-                status,
-                self._unhealthy_event_correlation_id(status.indexer_id, status.site_id),
-                self._build_unhealthy_event(status),
-            )
-            if applied and reopened_count:
-                logger.info(
-                    "Reopened recurring indexer site unhealthy events: indexer=%s site=%s count=%s",
-                    status.indexer_id,
-                    status.site_id,
-                    reopened_count,
-                )
-        except Exception as exc:
-            logger.error(
-                "Failed to reopen recurring indexer site unhealthy events for %s/%s: %s",
-                status.indexer_id,
-                status.site_id,
-                exc,
-            )
 
     def record_outcomes(self, outcomes: list[IndexerSiteSearchOutcome]) -> None:
         for outcome in outcomes:
@@ -217,20 +210,21 @@ class IndexerSiteHealthState:
                 now = current.checked_at + timedelta(microseconds=1)
             previous_failures = current.consecutive_failures if current else 0
             consecutive_failures = previous_failures + 1
-            should_emit = (
+            alert_threshold_reached = consecutive_failures >= INDEXER_SITE_FAILURE_NOTIFY_THRESHOLD
+            recovered_since_notification = bool(
                 consecutive_failures >= INDEXER_SITE_FAILURE_NOTIFY_THRESHOLD
-                and self._notify_cooldown_elapsed(current.last_notified_at if current else None, now)
-            )
-            should_reopen = bool(
-                consecutive_failures >= INDEXER_SITE_FAILURE_NOTIFY_THRESHOLD
-                and not should_emit
                 and current
                 and current.last_success_at
-                and current.last_notified_at
-                and current.last_success_at > current.last_notified_at
                 and (
-                    current.last_reopened_at is None
-                    or current.last_success_at > current.last_reopened_at
+                    current.last_notified_at is None
+                    or current.last_success_at > current.last_notified_at
+                )
+            )
+            should_emit = bool(
+                alert_threshold_reached
+                and (
+                    recovered_since_notification
+                    or self._notify_cooldown_elapsed(current.last_notified_at if current else None, now)
                 )
             )
             status = IndexerSiteHealthStatus(
@@ -253,10 +247,10 @@ class IndexerSiteHealthState:
             if applied:
                 break
             current = saved
+        if alert_threshold_reached and self._refresh_active_unhealthy_event(saved):
+            return self._get_record(indexer_id, site_id) or saved
         if should_emit:
             self._emit_unhealthy_event(saved, now)
-        elif should_reopen:
-            self._reopen_unhealthy_event(saved)
         return self._get_record(indexer_id, site_id) or saved
 
     @staticmethod

--- a/backend/tests/test_indexer_site_health_alerts.py
+++ b/backend/tests/test_indexer_site_health_alerts.py
@@ -26,6 +26,8 @@ class _FakeIndexerSiteHealthRepository:
         self.acknowledge_failures_remaining = 0
         self.acknowledged_calls: list[str] = []
         self.reopened_calls: list[str] = []
+        self.active_event_correlation_ids: set[str] = set()
+        self.refreshed_events = []
         self.before_acknowledge = None
         self.before_emit = None
         self.before_conditional_upsert = None
@@ -70,6 +72,7 @@ class _FakeIndexerSiteHealthRepository:
         if not current or current.status != "healthy" or current.checked_at != status.checked_at:
             return False, 0
         self.acknowledged_calls.append(correlation_id)
+        self.active_event_correlation_ids.discard(correlation_id)
         saved = current.model_copy(update={"notify_pending": False})
         self.records[(status.indexer_id, status.site_id)] = saved
         return True, 1
@@ -94,6 +97,21 @@ class _FakeIndexerSiteHealthRepository:
         saved = current.model_copy(update={"last_notified_at": notified_at})
         self.records[(status.indexer_id, status.site_id)] = saved
         self.emitted_events.append(event)
+        if event.correlation_id:
+            self.active_event_correlation_ids.add(event.correlation_id)
+        return True
+
+    def refresh_active_unhealthy_event_if_current(
+        self,
+        status: IndexerSiteHealthStatus,
+        event,
+    ) -> bool:
+        current = self.find_one(status.indexer_id, status.site_id)
+        if not current or current.status != "unhealthy" or current.checked_at != status.checked_at:
+            return False
+        if not event.correlation_id or event.correlation_id not in self.active_event_correlation_ids:
+            return False
+        self.refreshed_events.append(event)
         return True
 
     def reopen_unhealthy_events(
@@ -233,11 +251,11 @@ def test_indexer_site_unhealthy_event_respects_notification_cooldown(monkeypatch
             error_message="disabled again",
         )
 
-    assert len(repo.emitted_events) == 1
-    assert repo.reopened_calls == ["indexer:prowlarr:site:audiences:unhealthy"]
+    assert len(repo.emitted_events) == 2
+    assert repo.reopened_calls == []
 
 
-def test_indexer_site_recurring_failure_reopens_event_only_once(monkeypatch):
+def test_indexer_site_recurring_failure_emits_one_new_incident_after_recovery(monkeypatch):
     monkeypatch.setattr(
         "app.services.config.indexer_client_settings.event_service.dispatch_persisted_event",
         lambda _event: None,
@@ -268,7 +286,41 @@ def test_indexer_site_recurring_failure_reopens_event_only_once(monkeypatch):
             error_message="disabled again",
         )
 
-    assert repo.reopened_calls == ["indexer:prowlarr:site:audiences:unhealthy"]
+    assert len(repo.emitted_events) == 2
+    assert repo.reopened_calls == []
+
+
+def test_indexer_site_active_warning_refreshes_without_daily_telegram(monkeypatch):
+    monkeypatch.setattr(
+        "app.services.config.indexer_client_settings.event_service.dispatch_persisted_event",
+        lambda _event: None,
+    )
+    repo = _FakeIndexerSiteHealthRepository()
+    state = IndexerSiteHealthState(repo=repo)
+    for _ in range(3):
+        state.record_failure(
+            indexer_id="prowlarr",
+            indexer_name="Prowlarr",
+            site_id="audiences",
+            site_name="Audiences",
+            error_message="disabled",
+        )
+    current = repo.find_one("prowlarr", "audiences")
+    assert current is not None
+    repo.upsert(current.model_copy(update={"last_notified_at": datetime.now() - timedelta(hours=25)}))
+
+    state.record_failure(
+        indexer_id="prowlarr",
+        indexer_name="Prowlarr",
+        site_id="audiences",
+        site_name="Audiences",
+        error_message="still disabled",
+    )
+
+    assert len(repo.emitted_events) == 1
+    assert len(repo.refreshed_events) == 1
+    assert repo.refreshed_events[0].message_params["consecutive_failures"] == "4"
+    assert repo.refreshed_events[0].message_params["error"] == "still disabled"
 
 
 def test_indexer_site_success_acknowledges_unhealthy_warning_event(monkeypatch):
@@ -855,6 +907,72 @@ def test_emit_unhealthy_event_acknowledges_previous_matching_alert():
     assert applied is True
     assert persisted_current is not None
     assert acknowledged_ids == {previous_event.id}
+
+
+def test_refresh_active_unhealthy_event_updates_snapshot_without_new_dispatch():
+    repo = IndexerSiteHealthRepository()
+    checked_at = datetime.now()
+    correlation_id = "indexer:refresh-indexer:site:refresh-site:unhealthy"
+    status = IndexerSiteHealthStatus(
+        indexer_id="refresh-indexer",
+        indexer_name="Prowlarr",
+        site_id="refresh-site",
+        site_name="Refresh Site",
+        status="unhealthy",
+        checked_at=checked_at,
+        consecutive_failures=27,
+        notify_pending=True,
+    )
+    repo.upsert(status)
+    existing_event = Event(
+        id="active-refresh-warning",
+        ts=checked_at - timedelta(days=1),
+        type=EventTypes.INDEXER_SITE_UNHEALTHY,
+        level=EventLevel.warning,
+        message_params={"consecutive_failures": "3", "error": "disabled"},
+        correlation_id=correlation_id,
+    )
+    refreshed_event = Event(
+        id="unused-refresh-warning",
+        ts=checked_at,
+        type=EventTypes.INDEXER_SITE_UNHEALTHY,
+        level=EventLevel.warning,
+        message_params={"consecutive_failures": "27", "error": "still disabled"},
+        correlation_id=correlation_id,
+    )
+    with SessionLocal.begin() as session:
+        EventRepository.add_to_session(session, existing_event)
+
+    applied = repo.refresh_active_unhealthy_event_if_current(status, refreshed_event)
+
+    with SessionLocal.begin() as session:
+        rows = list(
+            session.execute(
+                select(EventORM).where(EventORM.correlation_id == correlation_id)
+            ).scalars().all()
+        )
+        dispatch_count = len(
+            list(
+                session.execute(
+                    select(EventDispatchORM).where(EventDispatchORM.event_id.in_([event.id for event in rows]))
+                ).scalars().all()
+            )
+        )
+        session.execute(delete(EventORM).where(EventORM.id == existing_event.id))
+        session.execute(
+            delete(IndexerSiteHealthORM).where(
+                IndexerSiteHealthORM.indexer_id == status.indexer_id,
+                IndexerSiteHealthORM.site_id == status.site_id,
+            )
+        )
+
+    assert applied is True
+    assert len(rows) == 1
+    assert rows[0].id == existing_event.id
+    assert rows[0].ts == checked_at.isoformat()
+    assert rows[0].message_params_json["consecutive_failures"] == "27"
+    assert rows[0].message_params_json["error"] == "still disabled"
+    assert dispatch_count == 0
 
 
 def test_emit_unhealthy_event_rolls_back_when_dispatch_queue_insert_fails():

--- a/backend/tests/test_indexer_site_health_alerts.py
+++ b/backend/tests/test_indexer_site_health_alerts.py
@@ -323,6 +323,32 @@ def test_indexer_site_active_warning_refreshes_without_daily_telegram(monkeypatc
     assert repo.refreshed_events[0].message_params["error"] == "still disabled"
 
 
+def test_indexer_site_refresh_failure_falls_back_to_first_notification(monkeypatch):
+    monkeypatch.setattr(
+        "app.services.config.indexer_client_settings.event_service.dispatch_persisted_event",
+        lambda _event: None,
+    )
+    repo = _FakeIndexerSiteHealthRepository()
+
+    def fail_refresh(*_args):
+        raise RuntimeError("event store unavailable")
+
+    monkeypatch.setattr(repo, "refresh_active_unhealthy_event_if_current", fail_refresh)
+    state = IndexerSiteHealthState(repo=repo)
+
+    for _ in range(3):
+        status = state.record_failure(
+            indexer_id="prowlarr",
+            indexer_name="Prowlarr",
+            site_id="audiences",
+            site_name="Audiences",
+            error_message="disabled",
+        )
+
+    assert len(repo.emitted_events) == 1
+    assert status.last_notified_at is not None
+
+
 def test_indexer_site_success_acknowledges_unhealthy_warning_event(monkeypatch):
     emitted_events = []
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary

- refresh an active unhealthy-indexer event instead of replacing it every 24 hours
- suppress repeated Telegram dispatch while the matching notification remains active
- notify immediately after a genuine recovery and recurrence, while retaining the 24-hour cooldown after manual dismissal

## Tests

- `./aethera.sh test-backend tests/test_indexer_site_health_alerts.py tests/test_telegram_notification_renderer.py` (30 passed)
- `./scripts/review_with_gates.sh` (250 backend tests passed; frontend quality, lint, and build passed)

## Risk

Low to moderate. The refresh is atomic with the current health snapshot and does not enqueue a new notification dispatch.