### PR TITLE
Delay indexer health notifications until 24 hours

### DIFF
--- a/backend/alembic/versions/0008_indexer_health_failure_window.py
+++ b/backend/alembic/versions/0008_indexer_health_failure_window.py
@@ -1,0 +1,47 @@
+"""Track uninterrupted indexer failure windows.
+
+Revision ID: 0008_indexer_failure_window
+Revises: 0007_scope_douban_overview
+Create Date: 2026-09-01
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0008_indexer_failure_window"
+down_revision = "0007_scope_douban_overview"
+branch_labels = None
+depends_on = None
+
+
+def _has_table(table_name: str) -> bool:
+    return sa.inspect(op.get_bind()).has_table(table_name)
+
+
+def _has_column(table_name: str, column_name: str) -> bool:
+    inspector = sa.inspect(op.get_bind())
+    return any(column["name"] == column_name for column in inspector.get_columns(table_name))
+
+
+def upgrade() -> None:
+    if not _has_table("indexer_site_health") or _has_column("indexer_site_health", "first_failure_at"):
+        return
+    op.add_column("indexer_site_health", sa.Column("first_failure_at", sa.Text(), nullable=True))
+    op.execute(
+        """
+        UPDATE indexer_site_health
+        SET first_failure_at = CASE
+            WHEN notify_pending = 1 THEN COALESCE(last_notified_at, last_failure_at, checked_at)
+            ELSE COALESCE(last_failure_at, checked_at)
+        END
+        WHERE status = 'unhealthy'
+        """
+    )
+
+
+def downgrade() -> None:
+    if _has_table("indexer_site_health") and _has_column("indexer_site_health", "first_failure_at"):
+        op.drop_column("indexer_site_health", "first_failure_at")

--- a/backend/app/db/repositories/event_repository.py
+++ b/backend/app/db/repositories/event_repository.py
@@ -45,8 +45,9 @@ class EventRepository:
         )
 
     @staticmethod
-    def refresh_snapshot(row: EventORM, event: Event) -> None:
-        row.ts = event.ts.isoformat()
+    def refresh_snapshot(row: EventORM, event: Event, *, preserve_ts: bool = False) -> None:
+        if not preserve_ts:
+            row.ts = event.ts.isoformat()
         row.message_key = event.message_key
         row.message_params_json = event.message_params
         row.search_text = build_event_search_text(event)

--- a/backend/app/db/repositories/event_repository.py
+++ b/backend/app/db/repositories/event_repository.py
@@ -8,6 +8,7 @@ from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 
 from app.db.sql.models import EventAcknowledgementORM, EventORM
 from app.db.sql.session import SessionLocal
+from app.schemas.constants.event_types import EventTypes
 from app.schemas.media_id import MediaID
 from app.schemas.domain.event import Event, EventLevel, EventSource, EventType
 from app.schemas.domain.media import MediaIdentity
@@ -384,14 +385,31 @@ class EventRepository:
             total = int(session.execute(select(func.count()).select_from(EventORM)).scalar_one() or 0)
             if total <= limit:
                 return 0
-            keep_ids = (
-                select(EventORM.id)
-                .order_by(desc(EventORM.ts))
-                .limit(limit)
-                .subquery()
+            acknowledgement_exists = (
+                select(EventAcknowledgementORM.event_id)
+                .where(EventAcknowledgementORM.event_id == EventORM.id)
+                .exists()
             )
+            active_ids = list(
+                session.execute(
+                    select(EventORM.id)
+                    .where(EventORM.type == EventTypes.INDEXER_SITE_UNHEALTHY.value)
+                    .where(EventORM.level == EventLevel.warning.value)
+                    .where(not_(acknowledgement_exists))
+                ).scalars().all()
+            )
+            acknowledged_limit = max(limit - len(active_ids), 0)
+            acknowledged_ids = list(
+                session.execute(
+                    select(EventORM.id)
+                    .where(EventORM.id.not_in(active_ids))
+                    .order_by(desc(EventORM.ts), desc(EventORM.id))
+                    .limit(acknowledged_limit)
+                ).scalars().all()
+            )
+            keep_ids = active_ids + acknowledged_ids
             result = session.execute(
-                delete(EventORM).where(EventORM.id.not_in(select(keep_ids.c.id)))
+                delete(EventORM).where(EventORM.id.not_in(keep_ids))
             )
             session.commit()
             return int(result.rowcount or 0)

--- a/backend/app/db/repositories/indexer_site_health_repository.py
+++ b/backend/app/db/repositories/indexer_site_health_repository.py
@@ -27,6 +27,7 @@ class IndexerSiteHealthRepository:
                 "status": row.status,
                 "checked_at": row.checked_at,
                 "last_success_at": row.last_success_at,
+                "first_failure_at": row.first_failure_at,
                 "last_failure_at": row.last_failure_at,
                 "consecutive_failures": row.consecutive_failures,
                 "last_error_message": row.last_error_message,
@@ -57,6 +58,7 @@ class IndexerSiteHealthRepository:
             row.status = status.status
             row.checked_at = status.checked_at.isoformat() if status.checked_at else None
             row.last_success_at = status.last_success_at.isoformat() if status.last_success_at else None
+            row.first_failure_at = status.first_failure_at.isoformat() if status.first_failure_at else None
             row.last_failure_at = status.last_failure_at.isoformat() if status.last_failure_at else None
             row.consecutive_failures = status.consecutive_failures
             row.last_error_message = status.last_error_message
@@ -74,6 +76,7 @@ class IndexerSiteHealthRepository:
         row.status = status.status
         row.checked_at = status.checked_at.isoformat() if status.checked_at else None
         row.last_success_at = status.last_success_at.isoformat() if status.last_success_at else None
+        row.first_failure_at = status.first_failure_at.isoformat() if status.first_failure_at else None
         row.last_failure_at = status.last_failure_at.isoformat() if status.last_failure_at else None
         row.consecutive_failures = status.consecutive_failures
         row.last_error_message = status.last_error_message
@@ -116,6 +119,7 @@ class IndexerSiteHealthRepository:
             and row.status == status.status
             and row.checked_at == iso(status.checked_at)
             and row.last_success_at == iso(status.last_success_at)
+            and row.first_failure_at == iso(status.first_failure_at)
             and row.last_failure_at == iso(status.last_failure_at)
             and row.consecutive_failures == status.consecutive_failures
             and row.last_error_message == status.last_error_message
@@ -213,7 +217,7 @@ class IndexerSiteHealthRepository:
             if active_event is None:
                 session.rollback()
                 return False
-            EventRepository.refresh_snapshot(active_event, event)
+            EventRepository.refresh_snapshot(active_event, event, preserve_ts=True)
             session.commit()
             return True
 

--- a/backend/app/db/sql/models.py
+++ b/backend/app/db/sql/models.py
@@ -437,6 +437,7 @@ class IndexerSiteHealthORM(Base):
     status: Mapped[str] = mapped_column(Text, nullable=False, index=True)
     checked_at: Mapped[str | None] = mapped_column(Text, nullable=True)
     last_success_at: Mapped[str | None] = mapped_column(Text, nullable=True)
+    first_failure_at: Mapped[str | None] = mapped_column(Text, nullable=True)
     last_failure_at: Mapped[str | None] = mapped_column(Text, nullable=True)
     consecutive_failures: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     last_error_message: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/backend/app/schemas/runtime/indexer_site_health.py
+++ b/backend/app/schemas/runtime/indexer_site_health.py
@@ -12,6 +12,7 @@ class IndexerSiteHealthStatus(BaseModel):
     status: Literal["healthy", "unhealthy", "unknown"] = "unknown"
     checked_at: Optional[datetime] = None
     last_success_at: Optional[datetime] = None
+    first_failure_at: Optional[datetime] = None
     last_failure_at: Optional[datetime] = None
     consecutive_failures: int = 0
     last_error_message: Optional[str] = None

--- a/backend/app/services/config/indexer_client_settings.py
+++ b/backend/app/services/config/indexer_client_settings.py
@@ -15,8 +15,7 @@ from app.schemas.runtime.indexer_site_health import IndexerSiteHealthStatus
 from app.services.audit.event_service import event_service
 
 
-INDEXER_SITE_FAILURE_NOTIFY_THRESHOLD = 3
-INDEXER_SITE_FAILURE_NOTIFY_COOLDOWN = timedelta(hours=24)
+INDEXER_SITE_FAILURE_NOTIFY_AFTER = timedelta(days=1)
 logger = logging.getLogger("app.services.config.indexer_client_settings")
 
 
@@ -159,9 +158,7 @@ class IndexerSiteHealthState:
             now = datetime.now()
             if current and current.checked_at and now <= current.checked_at:
                 now = current.checked_at + timedelta(microseconds=1)
-            should_acknowledge_unhealthy_event = bool(
-                current and (current.status == "unhealthy" or current.notify_pending)
-            )
+            should_acknowledge_unhealthy_event = bool(current and current.notify_pending)
             status = IndexerSiteHealthStatus(
                 indexer_id=indexer_id,
                 indexer_name=indexer_name,
@@ -170,11 +167,12 @@ class IndexerSiteHealthState:
                 status="healthy",
                 checked_at=now,
                 last_success_at=now,
+                first_failure_at=None,
                 last_failure_at=current.last_failure_at if current else None,
                 consecutive_failures=0,
                 last_error_message=None,
                 notify_pending=should_acknowledge_unhealthy_event,
-                last_notified_at=current.last_notified_at if current else None,
+                last_notified_at=None,
                 last_reopened_at=current.last_reopened_at if current else None,
                 client_type=client_type,
             )
@@ -210,22 +208,20 @@ class IndexerSiteHealthState:
                 now = current.checked_at + timedelta(microseconds=1)
             previous_failures = current.consecutive_failures if current else 0
             consecutive_failures = previous_failures + 1
-            alert_threshold_reached = consecutive_failures >= INDEXER_SITE_FAILURE_NOTIFY_THRESHOLD
-            recovered_since_notification = bool(
-                consecutive_failures >= INDEXER_SITE_FAILURE_NOTIFY_THRESHOLD
-                and current
-                and current.last_success_at
-                and (
-                    current.last_notified_at is None
-                    or current.last_success_at > current.last_notified_at
-                )
+            first_failure_at = (
+                current.first_failure_at
+                if current and current.status == "unhealthy" and current.first_failure_at
+                else now
             )
+            incident_last_notified_at = (
+                current.last_notified_at
+                if current and current.status == "unhealthy" and current.notify_pending
+                else None
+            )
+            notification_due = (now - first_failure_at) >= INDEXER_SITE_FAILURE_NOTIFY_AFTER
             should_emit = bool(
-                alert_threshold_reached
-                and (
-                    recovered_since_notification
-                    or self._notify_cooldown_elapsed(current.last_notified_at if current else None, now)
-                )
+                notification_due
+                and incident_last_notified_at is None
             )
             status = IndexerSiteHealthStatus(
                 indexer_id=indexer_id,
@@ -235,11 +231,12 @@ class IndexerSiteHealthState:
                 status="unhealthy",
                 checked_at=now,
                 last_success_at=current.last_success_at if current else None,
+                first_failure_at=first_failure_at,
                 last_failure_at=now,
                 consecutive_failures=consecutive_failures,
                 last_error_message=error_message,
-                notify_pending=consecutive_failures >= INDEXER_SITE_FAILURE_NOTIFY_THRESHOLD,
-                last_notified_at=current.last_notified_at if current else None,
+                notify_pending=bool(notification_due or (current and current.notify_pending)),
+                last_notified_at=incident_last_notified_at,
                 last_reopened_at=current.last_reopened_at if current else None,
                 client_type=client_type,
             )
@@ -247,15 +244,11 @@ class IndexerSiteHealthState:
             if applied:
                 break
             current = saved
-        if alert_threshold_reached and self._refresh_active_unhealthy_event(saved):
+        if saved.notify_pending and self._refresh_active_unhealthy_event(saved):
             return self._get_record(indexer_id, site_id) or saved
         if should_emit:
             self._emit_unhealthy_event(saved, now)
         return self._get_record(indexer_id, site_id) or saved
-
-    @staticmethod
-    def _notify_cooldown_elapsed(last_notified_at: datetime | None, now: datetime) -> bool:
-        return last_notified_at is None or (now - last_notified_at) >= INDEXER_SITE_FAILURE_NOTIFY_COOLDOWN
 
     def list_by_indexer(self, indexer_id: str) -> list[IndexerSiteHealthStatus]:
         return self._repo.list_by_indexer(indexer_id)

--- a/backend/tests/test_audit_retention_cleanup.py
+++ b/backend/tests/test_audit_retention_cleanup.py
@@ -3,7 +3,8 @@ from datetime import datetime, timedelta
 from app.db.repositories.action_repository import ActionRepository
 from app.db.repositories.event_dispatch_repository import EventDispatchRepository
 from app.db.repositories.event_repository import EventRepository
-from app.db.sql.models import ActionORM, EventDispatchORM, EventORM
+from app.db.sql.models import ActionORM, EventAcknowledgementORM, EventDispatchORM, EventORM
+from app.schemas.constants.event_types import EventTypes
 from app.db.sql.session import SessionLocal
 from app.schemas.persistence.event_dispatch import EventDispatchStatus
 
@@ -44,13 +45,13 @@ def _insert_action(session, item_id: str, minutes: int) -> None:
     )
 
 
-def _insert_event(session, item_id: str, minutes: int) -> None:
+def _insert_event(session, item_id: str, minutes: int, *, event_type: str = "test.event", level: str = "info") -> None:
     session.add(
         EventORM(
             id=item_id,
             ts=_iso(minutes),
-            type="test.event",
-            level="info",
+            type=event_type,
+            level=level,
             message_key=None,
             message_params_json={},
             search_text="",
@@ -149,6 +150,48 @@ def test_event_repository_skips_prune_when_under_limit():
 
     assert removed == 0
     assert remaining == ["event-skip-0", "event-skip-1"]
+
+
+def test_event_repository_preserves_unacknowledged_events_when_pruning():
+    with SessionLocal() as session:
+        session.query(EventAcknowledgementORM).delete()
+        session.query(EventORM).delete()
+        for index in range(4):
+            _insert_event(
+                session,
+                f"event-active-{index}",
+                index,
+                event_type=EventTypes.INDEXER_SITE_UNHEALTHY.value,
+                level="warning",
+            )
+        session.add_all(
+            EventAcknowledgementORM(
+                event_id=f"event-active-{index}",
+                acknowledged_at=_iso(4),
+            )
+            for index in (1, 2, 3)
+        )
+        session.commit()
+
+    removed = EventRepository().prune_to_limit(2)
+
+    with SessionLocal() as session:
+        remaining = [
+            row.id
+            for row in session.query(EventORM)
+            .filter(EventORM.id.like("event-active-%"))
+            .order_by(EventORM.ts.asc())
+            .all()
+        ]
+
+    assert removed == 2
+    assert remaining == ["event-active-0", "event-active-3"]
+
+    with SessionLocal.begin() as session:
+        session.query(EventAcknowledgementORM).filter(
+            EventAcknowledgementORM.event_id.like("event-active-%")
+        ).delete(synchronize_session=False)
+        session.query(EventORM).filter(EventORM.id.like("event-active-%")).delete(synchronize_session=False)
 
 
 def test_event_dispatch_repository_prunes_only_terminal_records():

--- a/backend/tests/test_indexer_site_health_alerts.py
+++ b/backend/tests/test_indexer_site_health_alerts.py
@@ -139,8 +139,21 @@ class _FakeIndexerSiteHealthRepository:
         return list(self.records.values())
 
 
-def test_indexer_site_failure_marks_notify_pending_after_threshold():
-    state = IndexerSiteHealthState(repo=_FakeIndexerSiteHealthRepository())
+def _age_failure_window(
+    repo: _FakeIndexerSiteHealthRepository,
+    *,
+    indexer_id: str = "prowlarr",
+    site_id: str = "audiences",
+    hours: int = 25,
+) -> None:
+    current = repo.find_one(indexer_id, site_id)
+    assert current is not None
+    repo.upsert(current.model_copy(update={"first_failure_at": datetime.now() - timedelta(hours=hours)}))
+
+
+def test_indexer_site_failure_does_not_notify_before_one_day():
+    repo = _FakeIndexerSiteHealthRepository()
+    state = IndexerSiteHealthState(repo=repo)
 
     for failure_count in range(1, 5):
         status = state.record_failure(
@@ -152,10 +165,35 @@ def test_indexer_site_failure_marks_notify_pending_after_threshold():
         )
 
     assert status.consecutive_failures == 4
-    assert status.notify_pending is True
+    assert status.notify_pending is False
+    assert repo.emitted_events == []
 
 
-def test_indexer_site_failure_emits_unhealthy_event_once_at_threshold(monkeypatch):
+def test_indexer_site_failure_at_twenty_three_hours_does_not_notify():
+    repo = _FakeIndexerSiteHealthRepository()
+    state = IndexerSiteHealthState(repo=repo)
+    state.record_failure(
+        indexer_id="prowlarr",
+        indexer_name="Prowlarr",
+        site_id="audiences",
+        site_name="Audiences",
+        error_message="disabled",
+    )
+    _age_failure_window(repo, hours=23)
+
+    status = state.record_failure(
+        indexer_id="prowlarr",
+        indexer_name="Prowlarr",
+        site_id="audiences",
+        site_name="Audiences",
+        error_message="still disabled",
+    )
+
+    assert status.notify_pending is False
+    assert repo.emitted_events == []
+
+
+def test_indexer_site_failure_emits_unhealthy_event_once_after_one_day(monkeypatch):
     emitted_events = []
     monkeypatch.setattr(
         "app.services.config.indexer_client_settings.event_service.dispatch_persisted_event",
@@ -164,7 +202,15 @@ def test_indexer_site_failure_emits_unhealthy_event_once_at_threshold(monkeypatc
     repo = _FakeIndexerSiteHealthRepository()
     state = IndexerSiteHealthState(repo=repo)
 
-    for failure_count in range(1, 5):
+    state.record_failure(
+        indexer_id="jackett",
+        indexer_name="Jackett",
+        site_id="audiences",
+        site_name="Audiences",
+        error_message="failure 1",
+    )
+    _age_failure_window(repo, indexer_id="jackett")
+    for failure_count in range(2, 5):
         state.record_failure(
             indexer_id="jackett",
             indexer_name="Jackett",
@@ -179,11 +225,43 @@ def test_indexer_site_failure_emits_unhealthy_event_once_at_threshold(monkeypatc
     assert event.level == EventLevel.warning
     assert event.message_params["indexer_name"] == "Jackett"
     assert event.message_params["site_name"] == "Audiences"
-    assert event.message_params["consecutive_failures"] == "3"
+    assert event.message_params["consecutive_failures"] == "2"
 
 
-def test_indexer_site_success_clears_notify_pending_and_allows_future_threshold():
-    state = IndexerSiteHealthState(repo=_FakeIndexerSiteHealthRepository())
+def test_unnotified_incident_ignores_historical_notification_timestamp():
+    repo = _FakeIndexerSiteHealthRepository()
+    repo.upsert(
+        IndexerSiteHealthStatus(
+            indexer_id="prowlarr",
+            indexer_name="Prowlarr",
+            site_id="audiences",
+            site_name="Audiences",
+            status="unhealthy",
+            checked_at=datetime.now() - timedelta(hours=1),
+            last_success_at=datetime.now() - timedelta(hours=1),
+            first_failure_at=datetime.now() - timedelta(hours=25),
+            last_failure_at=datetime.now() - timedelta(hours=1),
+            consecutive_failures=4,
+            notify_pending=False,
+            last_notified_at=datetime.now() - timedelta(days=7),
+        )
+    )
+    state = IndexerSiteHealthState(repo=repo)
+    notified = state.record_failure(
+        indexer_id="prowlarr",
+        indexer_name="Prowlarr",
+        site_id="audiences",
+        site_name="Audiences",
+        error_message="still disabled",
+    )
+
+    assert notified.last_notified_at is not None
+    assert len(repo.emitted_events) == 1
+
+
+def test_indexer_site_success_resets_failure_window():
+    repo = _FakeIndexerSiteHealthRepository()
+    state = IndexerSiteHealthState(repo=repo)
 
     for _ in range(3):
         state.record_failure(
@@ -216,10 +294,11 @@ def test_indexer_site_success_clears_notify_pending_and_allows_future_threshold(
     status = state._get_record("jackett", "audiences")
     assert status is not None
     assert status.consecutive_failures == 3
-    assert status.notify_pending is True
+    assert status.notify_pending is False
+    assert status.first_failure_at is not None
 
 
-def test_indexer_site_unhealthy_event_respects_notification_cooldown(monkeypatch):
+def test_indexer_site_short_failure_after_recovery_waits_another_day(monkeypatch):
     emitted_events = []
     monkeypatch.setattr(
         "app.services.config.indexer_client_settings.event_service.dispatch_persisted_event",
@@ -228,14 +307,21 @@ def test_indexer_site_unhealthy_event_respects_notification_cooldown(monkeypatch
     repo = _FakeIndexerSiteHealthRepository()
     state = IndexerSiteHealthState(repo=repo)
 
-    for _ in range(3):
-        state.record_failure(
-            indexer_id="prowlarr",
-            indexer_name="Prowlarr",
-            site_id="audiences",
-            site_name="Audiences",
-            error_message="disabled",
-        )
+    state.record_failure(
+        indexer_id="prowlarr",
+        indexer_name="Prowlarr",
+        site_id="audiences",
+        site_name="Audiences",
+        error_message="disabled",
+    )
+    _age_failure_window(repo)
+    state.record_failure(
+        indexer_id="prowlarr",
+        indexer_name="Prowlarr",
+        site_id="audiences",
+        site_name="Audiences",
+        error_message="disabled",
+    )
     state.record_success(
         indexer_id="prowlarr",
         indexer_name="Prowlarr",
@@ -251,7 +337,7 @@ def test_indexer_site_unhealthy_event_respects_notification_cooldown(monkeypatch
             error_message="disabled again",
         )
 
-    assert len(repo.emitted_events) == 2
+    assert len(repo.emitted_events) == 1
     assert repo.reopened_calls == []
 
 
@@ -263,28 +349,42 @@ def test_indexer_site_recurring_failure_emits_one_new_incident_after_recovery(mo
     repo = _FakeIndexerSiteHealthRepository()
     state = IndexerSiteHealthState(repo=repo)
 
-    for _ in range(3):
-        state.record_failure(
-            indexer_id="prowlarr",
-            indexer_name="Prowlarr",
-            site_id="audiences",
-            site_name="Audiences",
-            error_message="disabled",
-        )
+    state.record_failure(
+        indexer_id="prowlarr",
+        indexer_name="Prowlarr",
+        site_id="audiences",
+        site_name="Audiences",
+        error_message="disabled",
+    )
+    _age_failure_window(repo)
+    state.record_failure(
+        indexer_id="prowlarr",
+        indexer_name="Prowlarr",
+        site_id="audiences",
+        site_name="Audiences",
+        error_message="disabled",
+    )
     state.record_success(
         indexer_id="prowlarr",
         indexer_name="Prowlarr",
         site_id="audiences",
         site_name="Audiences",
     )
-    for _ in range(4):
-        state.record_failure(
-            indexer_id="prowlarr",
-            indexer_name="Prowlarr",
-            site_id="audiences",
-            site_name="Audiences",
-            error_message="disabled again",
-        )
+    state.record_failure(
+        indexer_id="prowlarr",
+        indexer_name="Prowlarr",
+        site_id="audiences",
+        site_name="Audiences",
+        error_message="disabled again",
+    )
+    _age_failure_window(repo)
+    state.record_failure(
+        indexer_id="prowlarr",
+        indexer_name="Prowlarr",
+        site_id="audiences",
+        site_name="Audiences",
+        error_message="disabled again",
+    )
 
     assert len(repo.emitted_events) == 2
     assert repo.reopened_calls == []
@@ -297,14 +397,21 @@ def test_indexer_site_active_warning_refreshes_without_daily_telegram(monkeypatc
     )
     repo = _FakeIndexerSiteHealthRepository()
     state = IndexerSiteHealthState(repo=repo)
-    for _ in range(3):
-        state.record_failure(
-            indexer_id="prowlarr",
-            indexer_name="Prowlarr",
-            site_id="audiences",
-            site_name="Audiences",
-            error_message="disabled",
-        )
+    state.record_failure(
+        indexer_id="prowlarr",
+        indexer_name="Prowlarr",
+        site_id="audiences",
+        site_name="Audiences",
+        error_message="disabled",
+    )
+    _age_failure_window(repo)
+    state.record_failure(
+        indexer_id="prowlarr",
+        indexer_name="Prowlarr",
+        site_id="audiences",
+        site_name="Audiences",
+        error_message="disabled",
+    )
     current = repo.find_one("prowlarr", "audiences")
     assert current is not None
     repo.upsert(current.model_copy(update={"last_notified_at": datetime.now() - timedelta(hours=25)}))
@@ -319,7 +426,7 @@ def test_indexer_site_active_warning_refreshes_without_daily_telegram(monkeypatc
 
     assert len(repo.emitted_events) == 1
     assert len(repo.refreshed_events) == 1
-    assert repo.refreshed_events[0].message_params["consecutive_failures"] == "4"
+    assert repo.refreshed_events[0].message_params["consecutive_failures"] == "3"
     assert repo.refreshed_events[0].message_params["error"] == "still disabled"
 
 
@@ -336,14 +443,21 @@ def test_indexer_site_refresh_failure_falls_back_to_first_notification(monkeypat
     monkeypatch.setattr(repo, "refresh_active_unhealthy_event_if_current", fail_refresh)
     state = IndexerSiteHealthState(repo=repo)
 
-    for _ in range(3):
-        status = state.record_failure(
-            indexer_id="prowlarr",
-            indexer_name="Prowlarr",
-            site_id="audiences",
-            site_name="Audiences",
-            error_message="disabled",
-        )
+    state.record_failure(
+        indexer_id="prowlarr",
+        indexer_name="Prowlarr",
+        site_id="audiences",
+        site_name="Audiences",
+        error_message="disabled",
+    )
+    _age_failure_window(repo)
+    status = state.record_failure(
+        indexer_id="prowlarr",
+        indexer_name="Prowlarr",
+        site_id="audiences",
+        site_name="Audiences",
+        error_message="disabled",
+    )
 
     assert len(repo.emitted_events) == 1
     assert status.last_notified_at is not None
@@ -358,14 +472,21 @@ def test_indexer_site_success_acknowledges_unhealthy_warning_event(monkeypatch):
     repo = _FakeIndexerSiteHealthRepository()
     state = IndexerSiteHealthState(repo=repo)
 
-    for _ in range(3):
-        state.record_failure(
-            indexer_id="prowlarr",
-            indexer_name="Prowlarr",
-            site_id="audiences",
-            site_name="Audiences",
-            error_message="disabled",
-        )
+    state.record_failure(
+        indexer_id="prowlarr",
+        indexer_name="Prowlarr",
+        site_id="audiences",
+        site_name="Audiences",
+        error_message="disabled",
+    )
+    _age_failure_window(repo)
+    state.record_failure(
+        indexer_id="prowlarr",
+        indexer_name="Prowlarr",
+        site_id="audiences",
+        site_name="Audiences",
+        error_message="disabled",
+    )
 
     state.record_success(
         indexer_id="prowlarr",
@@ -387,14 +508,21 @@ def test_indexer_site_success_retries_failed_recovery_acknowledgement(monkeypatc
     repo.acknowledge_failures_remaining = 1
     state = IndexerSiteHealthState(repo=repo)
 
-    for _ in range(3):
-        state.record_failure(
-            indexer_id="prowlarr",
-            indexer_name="Prowlarr",
-            site_id="audiences",
-            site_name="Audiences",
-            error_message="disabled",
-        )
+    state.record_failure(
+        indexer_id="prowlarr",
+        indexer_name="Prowlarr",
+        site_id="audiences",
+        site_name="Audiences",
+        error_message="disabled",
+    )
+    _age_failure_window(repo)
+    state.record_failure(
+        indexer_id="prowlarr",
+        indexer_name="Prowlarr",
+        site_id="audiences",
+        site_name="Audiences",
+        error_message="disabled",
+    )
 
     first_recovery = state.record_success(
         indexer_id="prowlarr",
@@ -422,14 +550,21 @@ def test_indexer_site_success_does_not_acknowledge_after_concurrent_failure(monk
     repo = _FakeIndexerSiteHealthRepository()
     state = IndexerSiteHealthState(repo=repo)
 
-    for _ in range(3):
-        state.record_failure(
-            indexer_id="prowlarr",
-            indexer_name="Prowlarr",
-            site_id="audiences",
-            site_name="Audiences",
-            error_message="disabled",
-        )
+    state.record_failure(
+        indexer_id="prowlarr",
+        indexer_name="Prowlarr",
+        site_id="audiences",
+        site_name="Audiences",
+        error_message="disabled",
+    )
+    _age_failure_window(repo)
+    state.record_failure(
+        indexer_id="prowlarr",
+        indexer_name="Prowlarr",
+        site_id="audiences",
+        site_name="Audiences",
+        error_message="disabled",
+    )
 
     def write_concurrent_failure():
         current = repo.find_one("prowlarr", "audiences")
@@ -505,14 +640,21 @@ def test_indexer_site_success_does_not_overwrite_failure_committed_after_read(mo
 def test_indexer_site_success_retries_after_notification_metadata_changes(monkeypatch):
     repo = _FakeIndexerSiteHealthRepository()
     state = IndexerSiteHealthState(repo=repo)
-    for _ in range(3):
-        state.record_failure(
-            indexer_id="prowlarr",
-            indexer_name="Prowlarr",
-            site_id="audiences",
-            site_name="Audiences",
-            error_message="disabled",
-        )
+    state.record_failure(
+        indexer_id="prowlarr",
+        indexer_name="Prowlarr",
+        site_id="audiences",
+        site_name="Audiences",
+        error_message="disabled",
+    )
+    _age_failure_window(repo)
+    state.record_failure(
+        indexer_id="prowlarr",
+        indexer_name="Prowlarr",
+        site_id="audiences",
+        site_name="Audiences",
+        error_message="disabled",
+    )
     current = repo.find_one("prowlarr", "audiences")
     assert current is not None
     notified_at = (current.last_notified_at or datetime.now()) + timedelta(seconds=1)
@@ -532,7 +674,7 @@ def test_indexer_site_success_retries_after_notification_metadata_changes(monkey
 
     assert recovered.status == "healthy"
     assert recovered.notify_pending is False
-    assert recovered.last_notified_at == notified_at
+    assert recovered.last_notified_at is None
     assert repo.acknowledged_calls == ["indexer:prowlarr:site:audiences:unhealthy"]
 
 
@@ -577,8 +719,8 @@ def test_indexer_site_failure_recalculates_after_concurrent_failure(monkeypatch)
     )
 
     assert saved.consecutive_failures == 3
-    assert saved.notify_pending is True
-    assert len(repo.emitted_events) == 1
+    assert saved.notify_pending is False
+    assert repo.emitted_events == []
 
 
 def test_indexer_site_failure_recalculates_after_notification_marker_changes(monkeypatch):
@@ -589,6 +731,15 @@ def test_indexer_site_failure_recalculates_after_notification_marker_changes(mon
     )
     repo = _FakeIndexerSiteHealthRepository()
     state = IndexerSiteHealthState(repo=repo)
+
+    state.record_failure(
+        indexer_id="prowlarr",
+        indexer_name="Prowlarr",
+        site_id="audiences",
+        site_name="Audiences",
+        error_message="disabled",
+    )
+    _age_failure_window(repo)
     for _ in range(2):
         state.record_failure(
             indexer_id="prowlarr",
@@ -597,6 +748,7 @@ def test_indexer_site_failure_recalculates_after_notification_marker_changes(mon
             site_name="Audiences",
             error_message="disabled",
         )
+    initial_emitted_count = len(repo.emitted_events)
 
     notified_at = datetime.now()
 
@@ -614,9 +766,9 @@ def test_indexer_site_failure_recalculates_after_notification_marker_changes(mon
         error_message="third failure",
     )
 
-    assert saved.consecutive_failures == 3
+    assert saved.consecutive_failures == 4
     assert saved.last_notified_at == notified_at
-    assert repo.emitted_events == []
+    assert len(repo.emitted_events) == initial_emitted_count
 
 
 def test_indexer_site_failure_does_not_emit_after_concurrent_recovery(monkeypatch):
@@ -627,6 +779,15 @@ def test_indexer_site_failure_does_not_emit_after_concurrent_recovery(monkeypatc
     )
     repo = _FakeIndexerSiteHealthRepository()
     state = IndexerSiteHealthState(repo=repo)
+
+    state.record_failure(
+        indexer_id="prowlarr",
+        indexer_name="Prowlarr",
+        site_id="audiences",
+        site_name="Audiences",
+        error_message="disabled",
+    )
+    _age_failure_window(repo)
 
     def write_concurrent_recovery():
         current = repo.find_one("prowlarr", "audiences")
@@ -643,14 +804,13 @@ def test_indexer_site_failure_does_not_emit_after_concurrent_recovery(monkeypatc
         )
 
     repo.before_emit = write_concurrent_recovery
-    for _ in range(3):
-        status = state.record_failure(
-            indexer_id="prowlarr",
-            indexer_name="Prowlarr",
-            site_id="audiences",
-            site_name="Audiences",
-            error_message="disabled",
-        )
+    status = state.record_failure(
+        indexer_id="prowlarr",
+        indexer_name="Prowlarr",
+        site_id="audiences",
+        site_name="Audiences",
+        error_message="disabled",
+    )
 
     assert status.status == "healthy"
     assert status.notify_pending is False
@@ -995,7 +1155,7 @@ def test_refresh_active_unhealthy_event_updates_snapshot_without_new_dispatch():
     assert applied is True
     assert len(rows) == 1
     assert rows[0].id == existing_event.id
-    assert rows[0].ts == checked_at.isoformat()
+    assert rows[0].ts == existing_event.ts.isoformat()
     assert rows[0].message_params_json["consecutive_failures"] == "27"
     assert rows[0].message_params_json["error"] == "still disabled"
     assert dispatch_count == 0
@@ -1061,7 +1221,7 @@ def test_emit_unhealthy_event_rolls_back_when_dispatch_queue_insert_fails():
     assert saved.last_notified_at is None
 
 
-def test_indexer_site_unhealthy_event_repeats_after_notification_cooldown(monkeypatch):
+def test_indexer_site_unhealthy_event_does_not_repeat_during_same_incident(monkeypatch):
     emitted_events = []
     monkeypatch.setattr(
         "app.services.config.indexer_client_settings.event_service.dispatch_persisted_event",
@@ -1091,10 +1251,10 @@ def test_indexer_site_unhealthy_event_repeats_after_notification_cooldown(monkey
         error_message="still disabled",
     )
 
-    assert len(repo.emitted_events) == 1
+    assert repo.emitted_events == []
 
 
-def test_indexer_site_unhealthy_event_failure_does_not_start_cooldown(monkeypatch):
+def test_indexer_site_unhealthy_event_failure_retries_without_resetting_window(monkeypatch):
     attempts = []
     monkeypatch.setattr(
         "app.services.config.indexer_client_settings.event_service.dispatch_persisted_event",
@@ -1104,14 +1264,21 @@ def test_indexer_site_unhealthy_event_failure_does_not_start_cooldown(monkeypatc
     repo.emit_failures_remaining = 1
     state = IndexerSiteHealthState(repo=repo)
 
-    for _ in range(3):
-        status = state.record_failure(
-            indexer_id="prowlarr",
-            indexer_name="Prowlarr",
-            site_id="audiences",
-            site_name="Audiences",
-            error_message="disabled",
-        )
+    state.record_failure(
+        indexer_id="prowlarr",
+        indexer_name="Prowlarr",
+        site_id="audiences",
+        site_name="Audiences",
+        error_message="disabled",
+    )
+    _age_failure_window(repo)
+    status = state.record_failure(
+        indexer_id="prowlarr",
+        indexer_name="Prowlarr",
+        site_id="audiences",
+        site_name="Audiences",
+        error_message="disabled",
+    )
 
     assert status.last_notified_at is None
 


### PR DESCRIPTION
## Summary
- wait for an uninterrupted 24-hour failure window before creating an indexer health alert
- send at most one notification per incident while refreshing the existing alert in place
- preserve the original alert timestamp and reset the window after recovery
- migrate existing indexer health state with backward-compatible failure-window data

## Tests
- `./scripts/review_with_gates.sh` (250 backend tests, frontend quality/lint/build)
- `./aethera.sh test-backend tests/test_media_profile_service_simple_info.py` (54 passed)
- focused indexer and notification regression suites (54 passed total)